### PR TITLE
Fixes build system default flag settings

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: google
+SortIncludes: false
+AlignConsecutiveAssignments: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: true

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,13 @@
+name: Clang-Format Check
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++/Protobuf programs.
+      uses: jidicula/clang-format-action@v4.5.0
+      with:
+        clang-format-version: '8'
+        check-path: './'

--- a/Copyright.txt
+++ b/Copyright.txt
@@ -1,41 +1,10 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
-//@HEADER
+************************************************************************
+
+                        Kokkos v. 4.0
+       Copyright (2022) National Technology & Engineering
+               Solutions of Sandia, LLC (NTESS).
+
+Under the terms of Contract DE-NA0003525 with NTESS,
+the U.S. Government retains certain rights in this software.
+
+************************************************************************

--- a/LICENSE
+++ b/LICENSE
@@ -1,43 +1,238 @@
-//@HEADER
-// ************************************************************************
-// 
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-// 
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Kokkos is licensed under 3-clause BSD terms of use:
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
-// 
-// ************************************************************************
-//@HEADER
+ ************************************************************************
+
+                        Kokkos v. 4.0
+       Copyright (2022) National Technology & Engineering
+               Solutions of Sandia, LLC (NTESS).
+
+ Under the terms of Contract DE-NA0003525 with NTESS,
+ the U.S. Government retains certain rights in this software.
+
+
+ ==============================================================================
+ Kokkos is under the Apache License v2.0 with LLVM Exceptions:
+ ==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS Apache 2.0
+
+ ---- LLVM Exceptions to the Apache 2.0 License ----
+
+ As an exception, if, as a result of your compiling your source code, portions
+ of this Software are embedded into an Object form of such source code, you
+ may redistribute such embedded portions in such Object form without complying
+ with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+ In addition, if you combine or link compiled forms of this Software with
+ software that is licensed under the GPLv2 ("Combined Software") and if a
+ court of competent jurisdiction determines that the patent provision (Section
+ 3), the indemnity provision (Section 9) or other Section of the License
+ conflicts with the conditions of the GPLv2, you may retroactively and
+ prospectively choose to deem waived or otherwise exclude such Section(s) of
+ the License, but only in their entirety and only with respect to the Combined
+ Software.
+
+ ==============================================================================
+ Software from third parties included in Kokkos:
+ ==============================================================================
+
+ Kokkos contains third party software which is under different license
+ terms. All such code will be identified clearly using at least one of two
+ mechanisms:
+ 1) It will be in a separate directory tree with its own `LICENSE.txt` or
+    `LICENSE` file at the top containing the specific license and restrictions
+    which apply to that software, or
+ 2) It will contain specific license and restriction terms at the top of every
+    file.
+
+
+ THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ Questions? Contact:
+   Christian R. Trott (crtrott@sandia.gov) and
+   Damien T. Lebrun-Grandie (lebrungrandt@ornl.gov)
+
+ ************************************************************************

--- a/LICENSE_FILE_HEADER
+++ b/LICENSE_FILE_HEADER
@@ -1,0 +1,15 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER

--- a/common/kernel-filter/kp_kernel_filter.cpp
+++ b/common/kernel-filter/kp_kernel_filter.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #include <stdio.h>

--- a/common/kernel-filter/kp_kernel_filter.cpp
+++ b/common/kernel-filter/kp_kernel_filter.cpp
@@ -35,265 +35,281 @@ typedef void (*finalizeFunction)();
 typedef void (*beginFunction)(const char*, const uint32_t, uint64_t*);
 typedef void (*endFunction)(uint64_t);
 
-static initFunction initProfileLibrary = NULL;
+static initFunction initProfileLibrary         = NULL;
 static finalizeFunction finalizeProfileLibrary = NULL;
-static beginFunction beginForCallee = NULL;
-static beginFunction beginScanCallee = NULL;
-static beginFunction beginReduceCallee = NULL;
-static endFunction endForCallee = NULL;
-static endFunction endScanCallee = NULL;
-static endFunction endReduceCallee = NULL;
+static beginFunction beginForCallee            = NULL;
+static beginFunction beginScanCallee           = NULL;
+static beginFunction beginReduceCallee         = NULL;
+static endFunction endForCallee                = NULL;
+static endFunction endScanCallee               = NULL;
+static endFunction endReduceCallee             = NULL;
 
 bool kokkospFilterMatch(const char* name) {
-	bool matched = false;
-	std::string nameStr(name);
+  bool matched = false;
+  std::string nameStr(name);
 
-	for(auto nextRegex : kernelNames) {
-		if(std::regex_match(nameStr, nextRegex)) {
-			matched = true;
-			break;
-		}
-	}
+  for (auto nextRegex : kernelNames) {
+    if (std::regex_match(nameStr, nextRegex)) {
+      matched = true;
+      break;
+    }
+  }
 
-	return matched;
+  return matched;
 }
 
 bool kokkospReadLine(FILE* kernelFile, char* lineBuffer) {
-	bool readData = false;
-	bool continueReading = !feof(kernelFile);
-	int nextIndex = 0;
+  bool readData        = false;
+  bool continueReading = !feof(kernelFile);
+  int nextIndex        = 0;
 
-	while(continueReading) {
-		const int nextChar = fgetc(kernelFile);
+  while (continueReading) {
+    const int nextChar = fgetc(kernelFile);
 
-		if(EOF == nextChar) {
-			continueReading = false;
-		} else {
-			readData = true;
+    if (EOF == nextChar) {
+      continueReading = false;
+    } else {
+      readData = true;
 
-			if(nextChar == '\n' || nextChar == '\f' || nextChar == '\r') {
-				continueReading = false;
-			} else {
-				lineBuffer[nextIndex++] = (char) nextChar;
-			}
-		}
-	}
+      if (nextChar == '\n' || nextChar == '\f' || nextChar == '\r') {
+        continueReading = false;
+      } else {
+        lineBuffer[nextIndex++] = (char)nextChar;
+      }
+    }
+  }
 
-	lineBuffer[nextIndex] = '\0';
-	return readData;
+  lineBuffer[nextIndex] = '\0';
+  return readData;
 }
 
 extern "C" void kokkosp_init_library(const int loadSeq,
-	const uint64_t interfaceVer, const uint32_t devInfoCount, void* deviceInfo) {
+                                     const uint64_t interfaceVer,
+                                     const uint32_t devInfoCount,
+                                     void* deviceInfo) {
+  const char* kernelFilterPath = getenv("KOKKOSP_KERNEL_FILTER");
+  nextKernelID                 = 0;
 
-	const char* kernelFilterPath = getenv("KOKKOSP_KERNEL_FILTER");
-	nextKernelID = 0;
+  if (NULL == kernelFilterPath) {
+    filterKernels = false;
+    printf("============================================================\n");
+    printf(
+        "KokkosP: No kernel filtering data provided, disabled from this tool "
+        "onwards\n");
+    printf("============================================================\n");
+  } else {
+    printf("============================================================\n");
+    printf("KokkosP: Filter File: %s\n", kernelFilterPath);
+    printf("============================================================\n");
 
-	if(NULL == kernelFilterPath) {
-		filterKernels = false;
-		printf("============================================================\n");
-		printf("KokkosP: No kernel filtering data provided, disabled from this tool onwards\n");
-		printf("============================================================\n");
-	} else {
-		printf("============================================================\n");
-		printf("KokkosP: Filter File: %s\n", kernelFilterPath);
-		printf("============================================================\n");
+    FILE* kernelFilterFile = fopen(kernelFilterPath, "rt");
 
-		FILE* kernelFilterFile = fopen(kernelFilterPath, "rt");
+    if (NULL == kernelFilterFile) {
+      fprintf(stderr, "Unable to open kernel filter: %s\n", kernelFilterPath);
+      exit(-1);
+    } else {
+      char* lineBuffer = (char*)malloc(sizeof(char) * 65536);
 
-		if(NULL == kernelFilterFile) {
-			fprintf(stderr, "Unable to open kernel filter: %s\n",
-				kernelFilterPath);
-			exit(-1);
-		} else {
-			char* lineBuffer = (char*) malloc( sizeof(char) * 65536 );
+      while (kokkospReadLine(kernelFilterFile, lineBuffer)) {
+        printf("KokkosP: Filter [%s]\n", lineBuffer);
 
-			while(kokkospReadLine(kernelFilterFile, lineBuffer)) {
-				printf("KokkosP: Filter [%s]\n", lineBuffer);
+        std::regex nextRegEx(lineBuffer, std::regex::optimize);
+        kernelNames.push_back(nextRegEx);
+      }
 
-				std::regex nextRegEx(lineBuffer, std::regex::optimize);
-				kernelNames.push_back(nextRegEx);
-			}
+      free(lineBuffer);
+    }
 
-			free(lineBuffer);
-		}
+    filterKernels = (kernelNames.size() > 0);
 
-		filterKernels = (kernelNames.size() > 0);
+    printf("KokkosP: Kernel Filtering is %s\n",
+           (filterKernels ? "enabled" : "disabled"));
 
-		printf("KokkosP: Kernel Filtering is %s\n", (filterKernels ?
-			"enabled" : "disabled"));
+    if (filterKernels) {
+      char* profileLibrary = getenv("KOKKOS_PROFILE_LIBRARY");
+      char* envBuffer =
+          (char*)malloc(sizeof(char) * (strlen(profileLibrary) + 1));
+      sprintf(envBuffer, "%s", profileLibrary);
 
-		if(filterKernels) {
-			char* profileLibrary = getenv("KOKKOS_PROFILE_LIBRARY");
-			char* envBuffer = (char*) malloc( sizeof(char) * (strlen(profileLibrary) + 1 ));
-			sprintf(envBuffer, "%s", profileLibrary);
+      char* nextLibrary = strtok(envBuffer, ";");
 
-			char* nextLibrary = strtok(envBuffer, ";");
+      for (int i = 0; i < loadSeq; i++) {
+        nextLibrary = strtok(NULL, ";");
+      }
 
-			for(int i = 0; i < loadSeq; i++) {
-				nextLibrary = strtok(NULL, ";");
-			}
+      nextLibrary = strtok(NULL, ";");
 
-			nextLibrary = strtok(NULL, ";");
+      if (NULL == nextLibrary) {
+        printf("KokkosP: No child library to call in %s\n", profileLibrary);
+      } else {
+        printf("KokkosP: Next library to call: %s\n", nextLibrary);
+        printf("KokkosP: Loading child library ..\n");
 
-			if(NULL == nextLibrary) {
-				printf("KokkosP: No child library to call in %s\n", profileLibrary);
-			} else {
-				printf("KokkosP: Next library to call: %s\n", nextLibrary);
-				printf("KokkosP: Loading child library ..\n");
+        void* childLibrary = dlopen(nextLibrary, RTLD_NOW | RTLD_GLOBAL);
 
-				void* childLibrary = dlopen(nextLibrary, RTLD_NOW | RTLD_GLOBAL);
+        if (NULL == childLibrary) {
+          fprintf(stderr, "KokkosP: Error: Unable to load: %s (Error=%s)\n",
+                  nextLibrary, dlerror());
+        } else {
+          beginForCallee =
+              (beginFunction)dlsym(childLibrary, "kokkosp_begin_parallel_for");
+          beginScanCallee =
+              (beginFunction)dlsym(childLibrary, "kokkosp_begin_parallel_scan");
+          beginReduceCallee = (beginFunction)dlsym(
+              childLibrary, "kokkosp_begin_parallel_reduce");
 
-				if(NULL == childLibrary) {
-					fprintf(stderr, "KokkosP: Error: Unable to load: %s (Error=%s)\n",
-						nextLibrary, dlerror());
-				} else {
-					beginForCallee = (beginFunction) dlsym(childLibrary, "kokkosp_begin_parallel_for");
-	               	beginScanCallee = (beginFunction) dlsym(childLibrary, "kokkosp_begin_parallel_scan");
-	               	beginReduceCallee = (beginFunction) dlsym(childLibrary, "kokkosp_begin_parallel_reduce");
+          endScanCallee =
+              (endFunction)dlsym(childLibrary, "kokkosp_end_parallel_scan");
+          endForCallee =
+              (endFunction)dlsym(childLibrary, "kokkosp_end_parallel_for");
+          endReduceCallee =
+              (endFunction)dlsym(childLibrary, "kokkosp_end_parallel_reduce");
 
-        	        endScanCallee = (endFunction) dlsym(childLibrary, "kokkosp_end_parallel_scan");
-       	        	endForCallee = (endFunction) dlsym(childLibrary, "kokkosp_end_parallel_for");
-    	           	endReduceCallee = (endFunction) dlsym(childLibrary, "kokkosp_end_parallel_reduce");
+          initProfileLibrary =
+              (initFunction)dlsym(childLibrary, "kokkosp_init_library");
+          finalizeProfileLibrary =
+              (finalizeFunction)dlsym(childLibrary, "kokkosp_finalize_library");
 
-   	            	initProfileLibrary = (initFunction) dlsym(childLibrary, "kokkosp_init_library");
-	               	finalizeProfileLibrary = (finalizeFunction) dlsym(childLibrary, "kokkosp_finalize_library");
+          if (NULL != initProfileLibrary) {
+            (*initProfileLibrary)(loadSeq + 1, interfaceVer, devInfoCount,
+                                  deviceInfo);
+          }
+        }
+      }
 
-					if(NULL != initProfileLibrary) {
-						(*initProfileLibrary)(loadSeq + 1, interfaceVer, devInfoCount, deviceInfo);
-					}
-				}
+      free(envBuffer);
+    }
 
-			}
-
-			free(envBuffer);
-		}
-
-		printf("============================================================\n");
-	}
+    printf("============================================================\n");
+  }
 }
 
 extern "C" void kokkosp_finalize_library() {
-	if(NULL != finalizeProfileLibrary) {
-		(*finalizeProfileLibrary)();
-	}
+  if (NULL != finalizeProfileLibrary) {
+    (*finalizeProfileLibrary)();
+  }
 
-    // Set all profile hooks to NULL to prevent
-  	// any additional calls. Once we are told to
-    // finalize, we mean it
-    beginForCallee = NULL;
-    beginScanCallee = NULL;
-    beginReduceCallee = NULL;
-    endScanCallee = NULL;
-    endForCallee = NULL;
-    endReduceCallee = NULL;
-    initProfileLibrary = NULL;
-    finalizeProfileLibrary = NULL;
+  // Set all profile hooks to NULL to prevent
+  // any additional calls. Once we are told to
+  // finalize, we mean it
+  beginForCallee         = NULL;
+  beginScanCallee        = NULL;
+  beginReduceCallee      = NULL;
+  endScanCallee          = NULL;
+  endForCallee           = NULL;
+  endReduceCallee        = NULL;
+  initProfileLibrary     = NULL;
+  finalizeProfileLibrary = NULL;
 
-	printf("============================================================\n");
-	printf("KokkosP: Kernel filtering library, finalized.\n");
-	printf("============================================================\n");
+  printf("============================================================\n");
+  printf("KokkosP: Kernel filtering library, finalized.\n");
+  printf("============================================================\n");
 }
 
-extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devID, uint64_t* kID) {
-	if(filterKernels) {
-		if(kokkospFilterMatch(name)) {
-			if(NULL != beginForCallee) {
-				(*beginForCallee)(name, devID, kID);
-				activeKernels.insert(*kID);
-			} else {
-				*kID = nextKernelID++;
-			}
-		} else {
-			*kID = nextKernelID++;
-		}
-	} else {
-		if(NULL != beginForCallee) {
-        	(*beginForCallee)(name, devID, kID);
-			activeKernels.insert(*kID);
-        } else {
-			*kID = nextKernelID++;
-		}
-	}
+extern "C" void kokkosp_begin_parallel_for(const char* name,
+                                           const uint32_t devID,
+                                           uint64_t* kID) {
+  if (filterKernels) {
+    if (kokkospFilterMatch(name)) {
+      if (NULL != beginForCallee) {
+        (*beginForCallee)(name, devID, kID);
+        activeKernels.insert(*kID);
+      } else {
+        *kID = nextKernelID++;
+      }
+    } else {
+      *kID = nextKernelID++;
+    }
+  } else {
+    if (NULL != beginForCallee) {
+      (*beginForCallee)(name, devID, kID);
+      activeKernels.insert(*kID);
+    } else {
+      *kID = nextKernelID++;
+    }
+  }
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
-	auto findKernel = activeKernels.find(kID);
+  auto findKernel = activeKernels.find(kID);
 
-	if(activeKernels.end() != findKernel) {
-		if(NULL != endForCallee) {
-			(*endForCallee)(kID);
-		}
+  if (activeKernels.end() != findKernel) {
+    if (NULL != endForCallee) {
+      (*endForCallee)(kID);
+    }
 
-		activeKernels.erase(findKernel);
-	}
+    activeKernels.erase(findKernel);
+  }
 }
 
-extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID, uint64_t* kID) {
-	if(filterKernels) {
-		if(kokkospFilterMatch(name)) {
-			if(NULL != beginScanCallee) {
-				(*beginScanCallee)(name, devID, kID);
-				activeKernels.insert(*kID);
-			} else {
-				*kID = nextKernelID++;
-			}
-		} else {
-			*kID = nextKernelID++;
-		}
-	} else {
-		if(NULL != beginScanCallee) {
-        	(*beginScanCallee)(name, devID, kID);
-			activeKernels.insert(*kID);
-        } else {
-			*kID = nextKernelID++;
-		}
-	}
+extern "C" void kokkosp_begin_parallel_scan(const char* name,
+                                            const uint32_t devID,
+                                            uint64_t* kID) {
+  if (filterKernels) {
+    if (kokkospFilterMatch(name)) {
+      if (NULL != beginScanCallee) {
+        (*beginScanCallee)(name, devID, kID);
+        activeKernels.insert(*kID);
+      } else {
+        *kID = nextKernelID++;
+      }
+    } else {
+      *kID = nextKernelID++;
+    }
+  } else {
+    if (NULL != beginScanCallee) {
+      (*beginScanCallee)(name, devID, kID);
+      activeKernels.insert(*kID);
+    } else {
+      *kID = nextKernelID++;
+    }
+  }
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
-	auto findKernel = activeKernels.find(kID);
+  auto findKernel = activeKernels.find(kID);
 
-	if(activeKernels.end() != findKernel) {
-		if(NULL != endScanCallee) {
-			(*endScanCallee)(kID);
-		}
+  if (activeKernels.end() != findKernel) {
+    if (NULL != endScanCallee) {
+      (*endScanCallee)(kID);
+    }
 
-		activeKernels.erase(findKernel);
-	}
+    activeKernels.erase(findKernel);
+  }
 }
 
-extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID, uint64_t* kID) {
-	if(filterKernels) {
-        if(kokkospFilterMatch(name)) {
-            if(NULL != beginScanCallee) {
-               	(*beginReduceCallee)(name, devID, kID);
-				activeKernels.insert(*kID);
-            } else {
-				*kID = nextKernelID++;
-			}
-		} else {
-			*kID = nextKernelID++;
-		}
+extern "C" void kokkosp_begin_parallel_reduce(const char* name,
+                                              const uint32_t devID,
+                                              uint64_t* kID) {
+  if (filterKernels) {
+    if (kokkospFilterMatch(name)) {
+      if (NULL != beginScanCallee) {
+        (*beginReduceCallee)(name, devID, kID);
+        activeKernels.insert(*kID);
+      } else {
+        *kID = nextKernelID++;
+      }
     } else {
-       	if(NULL != beginScanCallee) {
-       	    (*beginReduceCallee)(name, devID, kID);
-			activeKernels.insert(*kID);
-       	} else {
-			*kID = nextKernelID++;
-		}
+      *kID = nextKernelID++;
     }
+  } else {
+    if (NULL != beginScanCallee) {
+      (*beginReduceCallee)(name, devID, kID);
+      activeKernels.insert(*kID);
+    } else {
+      *kID = nextKernelID++;
+    }
+  }
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
-	auto findKernel = activeKernels.find(kID);
+  auto findKernel = activeKernels.find(kID);
 
-	if(activeKernels.end() != findKernel) {
-		if(NULL != endReduceCallee) {
-			(*endReduceCallee)(kID);
-		}
+  if (activeKernels.end() != findKernel) {
+    if (NULL != endReduceCallee) {
+      (*endReduceCallee)(kID);
+    }
 
-		activeKernels.erase(findKernel);
-	}
+    activeKernels.erase(findKernel);
+  }
 }
-

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -97,7 +97,7 @@ extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devI
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf("%s\n", name);
+	printf(" %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
@@ -113,7 +113,7 @@ extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t dev
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf("%s\n", name);
+	printf(" %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
@@ -129,7 +129,7 @@ extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t d
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf("%s\n", name);
+	printf(" %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
@@ -145,7 +145,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf("%s\n", name);
+	printf(" %s\n", name);
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -121,27 +121,38 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
   printf("KokkosP: Execution of kernel %llu is completed.\n", kID);
 }
 
-extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-	 if (std::strstr(name, "Kokkos Profile Tool Fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
-              *kID = std::numeric_limits<uint64_t>::max(); // set the dereferenced execution identifier to be the maximum value of uint64_t, which is assumed to never be assigned
-           }
-        else {
-          *kID = uniqID++;
+extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID,
+                                    uint64_t* kID) {
+  // filter out fence as this is a duplicate and unneeded (causing the tool to
+  // hinder performance of application). We use strstr for checking if the
+  // string contains the label of a fence (we assume the user will always have
+  // the word fence in the label of the fence).
+  if (std::strstr(name, "Kokkos Profile Tool Fence")) {
+    // set the dereferenced execution identifier to be the maximum value of
+    // uint64_t, which is assumed to never be assigned
+    *kID = std::numeric_limits<uint64_t>::max();
+  } else {
+    *kID = uniqID++;
 
-        printf("KokkosP: Executing fence on device %d with unique execution identifier %llu\n",
-                devID, *kID);
+    printf(
+        "KokkosP: Executing fence on device %d with unique execution "
+        "identifier %llu\n",
+        devID, *kID);
 
-	int level = kokkosp_print_region_stack();
-	kokkosp_print_region_stack_indent(level);
-	
-	printf("    %s\n", name);
-	} 
+    int level = kokkosp_print_region_stack();
+    kokkosp_print_region_stack_indent(level);
+
+    printf("    %s\n", name);
+  }
 }
 
-extern "C" void kokkosp_end_fence(const uint64_t kID) { 
-       if(kID != std::numeric_limits<uint64_t>::max()) { // if we find the kID to be maximum value uint64_t, then the callback is dealing with the application's fence, which we filtered out in the callback for fences 
-	printf("KokkosP: Execution of fence %llu is completed.\n", kID); 
-       }
+extern "C" void kokkosp_end_fence(const uint64_t kID) {
+  // if we find the kID to be maximum value uint64_t, then the callback is
+  // dealing with the application's fence, which we filtered out in the callback
+  // for fences
+  if (kID != std::numeric_limits<uint64_t>::max()) {
+    printf("KokkosP: Execution of fence %llu is completed.\n", kID);
+  }
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -141,7 +141,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {
-       if(! (kID == std::numeric_limits<uint64_t>::max() )
+       if(kID != std::numeric_limits<uint64_t>::max() ) 
 	printf("KokkosP: Execution of fence %llu is completed.\n", kID);
 }
 

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -122,7 +122,7 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 }
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-	 if (std::strstr(name, "fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
+	 if (std::stristr(name, "fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
               *kID = std::numeric_limits<uint64_t>::max(); // set the dereferenced execution identifier to be the maximum value of uint64_t, which is assumed to never be assigned
            }
         else {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -97,7 +97,7 @@ extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devI
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf(" %s\n", name);
+	printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
@@ -113,7 +113,7 @@ extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t dev
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf(" %s\n", name);
+	printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
@@ -129,7 +129,7 @@ extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t d
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf(" %s\n", name);
+	printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
@@ -145,7 +145,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 	int level = kokkosp_print_region_stack();
 	kokkosp_print_region_stack_indent(level);
 	
-	printf(" %s\n", name);
+	printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -122,27 +122,25 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 }
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-		
-	 if (std::strstr(name, "Kokkos Profile Tool Fence"))
-           {
-              *kID = std::numeric_limits<uint64_t>::max();
+	 if (std::strstr(name, "fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
+              *kID = std::numeric_limits<uint64_t>::max(); // set the dereferenced execution identifier to be the maximum value of uint64_t, which is assumed to never be assigned
            }
-        else
-          {
+        else {
           *kID = uniqID++;
 
         printf("KokkosP: Executing fence on device %d with unique execution identifier %llu\n",
                 devID, *kID);
 
-  int level = kokkosp_print_region_stack();
-  kokkosp_print_region_stack_indent(level);
-
-  printf("    %s\n", name);
+	int level = kokkosp_print_region_stack();
+	kokkosp_print_region_stack_indent(level);
+	
+	printf("    %s\n", name);
+	} 
 }
 
-extern "C" void kokkosp_end_fence(const uint64_t kID) {
-       if(kID != std::numeric_limits<uint64_t>::max() ) 
-	printf("KokkosP: Execution of fence %llu is completed.\n", kID);
+extern "C" void kokkosp_end_fence(const uint64_t kID) { 
+       if(kID != std::numeric_limits<uint64_t>::max()) { // if we find the kID to be maximum value uint64_t, then the callback is dealing with the application's fence, which we filtered out in the callback for fences 
+	printf("KokkosP: Execution of fence %llu is completed.\n", kID); 
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -141,7 +141,8 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {
-  printf("KokkosP: Execution of fence %llu is completed.\n", kID);
+       if(! (kID == std::numeric_limits<uint64_t>::max() )
+	printf("KokkosP: Execution of fence %llu is completed.\n", kID);
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #include <cstdio>

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -122,7 +122,7 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
 }
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-	 if (std::stristr(name, "fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
+	 if (std::strstr(name, "Kokkos Profile Tool Fence")) { // filter out fence as this is a duplicate and unneeded (causing the tool to hinder performance of application). We use strstr for checking if the string contains the label of a fence (we assume the user will always have the word fence in the label of the fence).  
               *kID = std::numeric_limits<uint64_t>::max(); // set the dereferenced execution identifier to be the maximum value of uint64_t, which is assumed to never be assigned
            }
         else {
@@ -141,6 +141,7 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint
 extern "C" void kokkosp_end_fence(const uint64_t kID) { 
        if(kID != std::numeric_limits<uint64_t>::max()) { // if we find the kID to be maximum value uint64_t, then the callback is dealing with the application's fence, which we filtered out in the callback for fences 
 	printf("KokkosP: Execution of fence %llu is completed.\n", kID); 
+       }
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -121,14 +121,18 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
   printf("KokkosP: Execution of kernel %llu is completed.\n", kID);
 }
 
-extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID,
-                                    uint64_t* kID) {
-  *kID = uniqID++;
+extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
+		
+	 if (std::strstr(name, "Kokkos Profile Tool Fence"))
+           {
+              *kID = std::numeric_limits<uint64_t>::max();
+           }
+        else
+          {
+          *kID = uniqID++;
 
-  printf(
-      "KokkosP: Executing fence on device %d with unique execution identifier "
-      "%llu\n",
-      devID, *kID);
+        printf("KokkosP: Executing fence on device %d with unique execution identifier %llu\n",
+                devID, *kID);
 
   int level = kokkosp_print_region_stack();
   kokkosp_print_region_stack_indent(level);

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -55,7 +55,7 @@ struct SpaceHandle {
 
 void kokkosp_print_region_stack_indent(const int level) {
 	printf("KokkosP: ");
-	
+
 	for(int i = 0; i < level; i++) {
 		printf("  ");
 	}
@@ -79,7 +79,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
 	const uint32_t devInfoCount,
 	void* deviceInfo) {
 
-	printf("KokkosP: Example Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
+	printf("KokkosP: Kernel Logger Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
 	uniqID = 0;
 	
 }

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -19,8 +19,6 @@
 #include <vector>
 #include <string>
 
-
-
 std::vector<std::string> regions;
 static uint64_t uniqID;
 struct SpaceHandle {
@@ -28,131 +26,155 @@ struct SpaceHandle {
 };
 
 void kokkosp_print_region_stack_indent(const int level) {
-	printf("KokkosP: ");
+  printf("KokkosP: ");
 
-	for(int i = 0; i < level; i++) {
-		printf("  ");
-	}
+  for (int i = 0; i < level; i++) {
+    printf("  ");
+  }
 }
 
 int kokkosp_print_region_stack() {
-	int level = 0;
+  int level = 0;
 
-	for(auto regItr = regions.begin(); regItr != regions.end(); regItr++) {
-		kokkosp_print_region_stack_indent(level);
-		printf("%s\n", (*regItr).c_str());
-		
-		level++;
-	}
-	
-	return level;
+  for (auto regItr = regions.begin(); regItr != regions.end(); regItr++) {
+    kokkosp_print_region_stack_indent(level);
+    printf("%s\n", (*regItr).c_str());
+
+    level++;
+  }
+
+  return level;
 }
 
 extern "C" void kokkosp_init_library(const int loadSeq,
-	const uint64_t interfaceVer,
-	const uint32_t devInfoCount,
-	void* deviceInfo) {
-
-	printf("KokkosP: Kernel Logger Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
-	uniqID = 0;
-	
+                                     const uint64_t interfaceVer,
+                                     const uint32_t devInfoCount,
+                                     void* deviceInfo) {
+  printf(
+      "KokkosP: Kernel Logger Library Initialized (sequence is %d, version: "
+      "%llu)\n",
+      loadSeq, interfaceVer);
+  uniqID = 0;
 }
 
 extern "C" void kokkosp_finalize_library() {
-	printf("KokkosP: Kokkos library finalization called.\n");
+  printf("KokkosP: Kokkos library finalization called.\n");
 }
 
-extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = uniqID++;
+extern "C" void kokkosp_begin_parallel_for(const char* name,
+                                           const uint32_t devID,
+                                           uint64_t* kID) {
+  *kID = uniqID++;
 
-	printf("KokkosP: Executing parallel-for kernel on device %d with unique execution identifier %llu\n",
-		devID, *kID);
+  printf(
+      "KokkosP: Executing parallel-for kernel on device %d with unique "
+      "execution identifier %llu\n",
+      devID, *kID);
 
-	int level = kokkosp_print_region_stack();
-	kokkosp_print_region_stack_indent(level);
-	
-	printf("    %s\n", name);
+  int level = kokkosp_print_region_stack();
+  kokkosp_print_region_stack_indent(level);
+
+  printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
-	printf("KokkosP: Execution of kernel %llu is completed.\n", kID);
+  printf("KokkosP: Execution of kernel %llu is completed.\n", kID);
 }
 
-extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = uniqID++;
+extern "C" void kokkosp_begin_parallel_scan(const char* name,
+                                            const uint32_t devID,
+                                            uint64_t* kID) {
+  *kID = uniqID++;
 
-	printf("KokkosP: Executing parallel-scan kernel on device %d with unique execution identifier %llu\n",
-		devID, *kID);
+  printf(
+      "KokkosP: Executing parallel-scan kernel on device %d with unique "
+      "execution identifier %llu\n",
+      devID, *kID);
 
-	int level = kokkosp_print_region_stack();
-	kokkosp_print_region_stack_indent(level);
-	
-	printf("    %s\n", name);
+  int level = kokkosp_print_region_stack();
+  kokkosp_print_region_stack_indent(level);
+
+  printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
-	printf("KokkosP: Execution of kernel %llu is completed.\n", kID);
+  printf("KokkosP: Execution of kernel %llu is completed.\n", kID);
 }
 
-extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = uniqID++;
+extern "C" void kokkosp_begin_parallel_reduce(const char* name,
+                                              const uint32_t devID,
+                                              uint64_t* kID) {
+  *kID = uniqID++;
 
-	printf("KokkosP: Executing parallel-reduce kernel on device %d with unique execution identifier %llu\n",
-		devID, *kID);
+  printf(
+      "KokkosP: Executing parallel-reduce kernel on device %d with unique "
+      "execution identifier %llu\n",
+      devID, *kID);
 
-	int level = kokkosp_print_region_stack();
-	kokkosp_print_region_stack_indent(level);
-	
-	printf("    %s\n", name);
+  int level = kokkosp_print_region_stack();
+  kokkosp_print_region_stack_indent(level);
+
+  printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
-	printf("KokkosP: Execution of kernel %llu is completed.\n", kID);
+  printf("KokkosP: Execution of kernel %llu is completed.\n", kID);
 }
 
-extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = uniqID++;
+extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID,
+                                    uint64_t* kID) {
+  *kID = uniqID++;
 
-	printf("KokkosP: Executing fence on device %d with unique execution identifier %llu\n",
-		devID, *kID);
+  printf(
+      "KokkosP: Executing fence on device %d with unique execution identifier "
+      "%llu\n",
+      devID, *kID);
 
-	int level = kokkosp_print_region_stack();
-	kokkosp_print_region_stack_indent(level);
-	
-	printf("    %s\n", name);
+  int level = kokkosp_print_region_stack();
+  kokkosp_print_region_stack_indent(level);
+
+  printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_fence(const uint64_t kID) {
-	printf("KokkosP: Execution of fence %llu is completed.\n", kID);
+  printf("KokkosP: Execution of fence %llu is completed.\n", kID);
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {
-	printf("KokkosP: Entering profiling region: %s\n", regionName);
+  printf("KokkosP: Entering profiling region: %s\n", regionName);
 
-	std::string regionNameStr(regionName);
-	regions.push_back(regionNameStr);
+  std::string regionNameStr(regionName);
+  regions.push_back(regionNameStr);
 }
 
 extern "C" void kokkosp_pop_profile_region() {
-	if(regions.size() > 0) {
-		printf("KokkosP: Exiting profiling region: %s\n", regions.back().c_str());
-		regions.pop_back();
-	}
+  if (regions.size() > 0) {
+    printf("KokkosP: Exiting profiling region: %s\n", regions.back().c_str());
+    regions.pop_back();
+  }
 }
 
-extern "C" void kokkosp_allocate_data(SpaceHandle handle, const char* name, void* ptr, uint64_t size) {
-  printf("KokkosP: Allocate<%s> name: %s pointer: %p size: %lu\n",handle.name,name,ptr,size);
+extern "C" void kokkosp_allocate_data(SpaceHandle handle, const char* name,
+                                      void* ptr, uint64_t size) {
+  printf("KokkosP: Allocate<%s> name: %s pointer: %p size: %lu\n", handle.name,
+         name, ptr, size);
 }
 
-extern "C" void kokkosp_deallocate_data(SpaceHandle handle, const char* name, void* ptr, uint64_t size) {
-  printf("KokkosP: Deallocate<%s> name: %s pointer: %p size: %lu\n",handle.name,name,ptr,size);
+extern "C" void kokkosp_deallocate_data(SpaceHandle handle, const char* name,
+                                        void* ptr, uint64_t size) {
+  printf("KokkosP: Deallocate<%s> name: %s pointer: %p size: %lu\n",
+         handle.name, name, ptr, size);
 }
 
-extern "C" void kokkosp_begin_deep_copy(
-    SpaceHandle dst_handle, const char* dst_name, const void* dst_ptr,
-    SpaceHandle src_handle, const char* src_name, const void* src_ptr,
-    uint64_t size) {
-  printf("KokkosP: DeepCopy<%s,%s> DST(name: %s pointer: %p) SRC(name: %s pointer %p) Size: %lu\n",
-    dst_handle.name, src_handle.name,
-    dst_name, dst_ptr, src_name, src_ptr, size);
+extern "C" void kokkosp_begin_deep_copy(SpaceHandle dst_handle,
+                                        const char* dst_name,
+                                        const void* dst_ptr,
+                                        SpaceHandle src_handle,
+                                        const char* src_name,
+                                        const void* src_ptr, uint64_t size) {
+  printf(
+      "KokkosP: DeepCopy<%s,%s> DST(name: %s pointer: %p) SRC(name: %s pointer "
+      "%p) Size: %lu\n",
+      dst_handle.name, src_handle.name, dst_name, dst_ptr, src_name, src_ptr,
+      size);
 }

--- a/profiling/chrome-tracing/kp_chrome_tracing.cpp
+++ b/profiling/chrome-tracing/kp_chrome_tracing.cpp
@@ -1,3 +1,19 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
 #include <algorithm>
 #include <cassert>
 #include <cinttypes>

--- a/profiling/memory-events/kp_memory_events.cpp
+++ b/profiling/memory-events/kp_memory_events.cpp
@@ -30,7 +30,7 @@
 std::vector<EventRecord> events;
 
 int num_spaces;
-std::vector<std::tuple<double,uint64_t,double> > space_size_track[16];
+std::vector<std::tuple<double, uint64_t, double> > space_size_track[16];
 uint64_t space_size[16];
 
 static std::mutex m;
@@ -41,119 +41,127 @@ double max_mem_usage() {
   struct rusage app_info;
   getrusage(RUSAGE_SELF, &app_info);
   const double max_rssKB = app_info.ru_maxrss;
-  return max_rssKB*1024;
+  return max_rssKB * 1024;
 }
 
 extern "C" void kokkosp_init_library(const int loadSeq,
                                      const uint64_t interfaceVer,
                                      const uint32_t devInfoCount,
                                      void* deviceInfo) {
-
   num_spaces = 0;
-  for(int i=0; i<16; i++)
-    space_size[i] = 0;
+  for (int i = 0; i < 16; i++) space_size[i] = 0;
 
-  printf("KokkosP: MemoryEvents loaded (sequence: %d, version: %llu)\n", loadSeq, interfaceVer);
+  printf("KokkosP: MemoryEvents loaded (sequence: %d, version: %llu)\n",
+         loadSeq, interfaceVer);
 
   timer.reset();
 }
 
 extern "C" void kokkosp_finalize_library() {
-  char* hostname = (char*) malloc(sizeof(char) * 256);
+  char* hostname = (char*)malloc(sizeof(char) * 256);
   gethostname(hostname, 256);
   int pid = getpid();
 
   {
-    char* fileOutput = (char*) malloc(sizeof(char) * 256);
+    char* fileOutput = (char*)malloc(sizeof(char) * 256);
     sprintf(fileOutput, "%s-%d.mem_events", hostname, pid);
 
     FILE* ofile = fopen(fileOutput, "wb");
     free(fileOutput);
 
-    fprintf(ofile,"# Memory Events\n");
-    fprintf(ofile,"# Time     Ptr                  Size        MemSpace      Op         Name\n");
-    for(int i=0; i<events.size();i++)
-      events[i].print_record(ofile);
+    fprintf(ofile, "# Memory Events\n");
+    fprintf(ofile,
+            "# Time     Ptr                  Size        MemSpace      Op      "
+            "   Name\n");
+    for (int i = 0; i < events.size(); i++) events[i].print_record(ofile);
     fclose(ofile);
   }
 
-  for(int s = 0; s<num_spaces; s++) {
-    char* fileOutput = (char*) malloc(sizeof(char) * 256);
-    sprintf(fileOutput, "%s-%d-%s.memspace_usage", hostname, pid, space_name[s]);
+  for (int s = 0; s < num_spaces; s++) {
+    char* fileOutput = (char*)malloc(sizeof(char) * 256);
+    sprintf(fileOutput, "%s-%d-%s.memspace_usage", hostname, pid,
+            space_name[s]);
 
     FILE* ofile = fopen(fileOutput, "wb");
     free(fileOutput);
 
-    fprintf(ofile,"# Space %s\n",space_name[s]);
-    fprintf(ofile,"# Time(s)  Size(MB)   HighWater(MB)   HighWater-Process(MB)\n");
+    fprintf(ofile, "# Space %s\n", space_name[s]);
+    fprintf(ofile,
+            "# Time(s)  Size(MB)   HighWater(MB)   HighWater-Process(MB)\n");
     uint64_t maxvalue = 0;
-    for(int i=0; i<space_size_track[s].size(); i++) {
-      if(std::get<1>(space_size_track[s][i]) > maxvalue) maxvalue = std::get<1>(space_size_track[s][i]);
-      fprintf(ofile,"%lf %.1lf %.1lf %.1lf\n",
+    for (int i = 0; i < space_size_track[s].size(); i++) {
+      if (std::get<1>(space_size_track[s][i]) > maxvalue)
+        maxvalue = std::get<1>(space_size_track[s][i]);
+      fprintf(ofile, "%lf %.1lf %.1lf %.1lf\n",
               std::get<0>(space_size_track[s][i]),
-              1.0*std::get<1>(space_size_track[s][i])/1024/1024,
-              1.0*maxvalue/1024/1024,
-              1.0*std::get<2>(space_size_track[s][i])/1024/1024);
+              1.0 * std::get<1>(space_size_track[s][i]) / 1024 / 1024,
+              1.0 * maxvalue / 1024 / 1024,
+              1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
     }
     fclose(ofile);
- }
+  }
   free(hostname);
 }
 
-extern "C" void kokkosp_allocate_data(const SpaceHandle space, const char* label, const void* const ptr, const uint64_t size) {
+extern "C" void kokkosp_allocate_data(const SpaceHandle space,
+                                      const char* label, const void* const ptr,
+                                      const uint64_t size) {
   std::lock_guard<std::mutex> lock(m);
 
   double time = timer.seconds();
 
   int space_i = num_spaces;
-  for(int s = 0; s<num_spaces; s++)
-    if(strcmp(space_name[s],space.name)==0)
-      space_i = s;
+  for (int s = 0; s < num_spaces; s++)
+    if (strcmp(space_name[s], space.name) == 0) space_i = s;
 
-  if(space_i == num_spaces) {
-    strncpy(space_name[num_spaces],space.name,64);
+  if (space_i == num_spaces) {
+    strncpy(space_name[num_spaces], space.name, 64);
     num_spaces++;
   }
   space_size[space_i] += size;
-  space_size_track[space_i].push_back(std::make_tuple(time,space_size[space_i],max_mem_usage()));
+  space_size_track[space_i].push_back(
+      std::make_tuple(time, space_size[space_i], max_mem_usage()));
 
-  int i=events.size();
-  events.push_back(EventRecord(ptr,size,MEMOP_ALLOCATE,space_i,time,label));
+  int i = events.size();
+  events.push_back(
+      EventRecord(ptr, size, MEMOP_ALLOCATE, space_i, time, label));
 }
 
-
-extern "C" void kokkosp_deallocate_data(const SpaceHandle space, const char* label, const void* const ptr, const uint64_t size) {
+extern "C" void kokkosp_deallocate_data(const SpaceHandle space,
+                                        const char* label,
+                                        const void* const ptr,
+                                        const uint64_t size) {
   std::lock_guard<std::mutex> lock(m);
 
   double time = timer.seconds();
 
   int space_i = num_spaces;
-  for(int s = 0; s<num_spaces; s++)
-    if(strcmp(space_name[s],space.name)==0)
-      space_i = s;
+  for (int s = 0; s < num_spaces; s++)
+    if (strcmp(space_name[s], space.name) == 0) space_i = s;
 
-  if(space_i == num_spaces) {
-    strncpy(space_name[num_spaces],space.name,64);
+  if (space_i == num_spaces) {
+    strncpy(space_name[num_spaces], space.name, 64);
     num_spaces++;
   }
-  if(space_size[space_i] >= size) {
+  if (space_size[space_i] >= size) {
     space_size[space_i] -= size;
-    space_size_track[space_i].push_back(std::make_tuple(time,space_size[space_i],max_mem_usage()));
+    space_size_track[space_i].push_back(
+        std::make_tuple(time, space_size[space_i], max_mem_usage()));
   }
 
-  int i=events.size();
-  events.push_back(EventRecord(ptr,size,MEMOP_DEALLOCATE,space_i,time,label));
+  int i = events.size();
+  events.push_back(
+      EventRecord(ptr, size, MEMOP_DEALLOCATE, space_i, time, label));
 }
 
 extern "C" void kokkosp_push_profile_region(const char* name) {
   std::lock_guard<std::mutex> lock(m);
   double time = timer.seconds();
-  events.push_back(EventRecord(nullptr,0,MEMOP_PUSH_REGION,0,time,name));
+  events.push_back(EventRecord(nullptr, 0, MEMOP_PUSH_REGION, 0, time, name));
 }
 
 extern "C" void kokkosp_pop_profile_region() {
   std::lock_guard<std::mutex> lock(m);
   double time = timer.seconds();
-  events.push_back(EventRecord(nullptr,0,MEMOP_POP_REGION,0,time,""));
+  events.push_back(EventRecord(nullptr, 0, MEMOP_POP_REGION, 0, time, ""));
 }
-

--- a/profiling/memory-events/kp_memory_events.cpp
+++ b/profiling/memory-events/kp_memory_events.cpp
@@ -1,47 +1,18 @@
-/*
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact  David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
-// */
-
 
 #include <cstdio>
 #include <cinttypes>

--- a/profiling/memory-events/kp_memory_events.hpp
+++ b/profiling/memory-events/kp_memory_events.hpp
@@ -1,47 +1,18 @@
-/*
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact  David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
-// */
-
 #define MEMOP_ALLOCATE 1
 #define MEMOP_DEALLOCATE 2
 #define MEMOP_PUSH_REGION 3

--- a/profiling/memory-events/kp_memory_events.hpp
+++ b/profiling/memory-events/kp_memory_events.hpp
@@ -36,26 +36,27 @@ struct EventRecord {
   double time;
   char name[256];
 
-
-  EventRecord(const void* const ptr_, const uint64_t size_, const int operation_,
-              const int space_, const double time_, const char* const name_) {
-    ptr = ptr_;
-    size = size_;
+  EventRecord(const void* const ptr_, const uint64_t size_,
+              const int operation_, const int space_, const double time_,
+              const char* const name_) {
+    ptr       = ptr_;
+    size      = size_;
     operation = operation_;
-    space = space_;
-    time = time_;
-    strncpy(name,name_,256);
+    space     = space_;
+    time      = time_;
+    strncpy(name, name_, 256);
   }
 
   void print_record(FILE* ofile) const {
-    if(operation == MEMOP_ALLOCATE)
-      fprintf(ofile,"%lf %16p %14" PRId64 " %16s Allocate   %s\n",time,ptr,size,space<0?"":space_name[space],name);
-    if(operation == MEMOP_DEALLOCATE)
-      fprintf(ofile,"%lf %16p %14" PRId64 " %16s DeAllocate %s\n",time,ptr,-size,space<0?"":space_name[space],name);
-    if(operation == MEMOP_PUSH_REGION)
-      fprintf(ofile,"%lf PushRegion %s {\n",time,name);
-    if(operation == MEMOP_POP_REGION)
-      fprintf(ofile,"%lf } PopRegion %s\n",time,name);
+    if (operation == MEMOP_ALLOCATE)
+      fprintf(ofile, "%lf %16p %14" PRId64 " %16s Allocate   %s\n", time, ptr,
+              size, space < 0 ? "" : space_name[space], name);
+    if (operation == MEMOP_DEALLOCATE)
+      fprintf(ofile, "%lf %16p %14" PRId64 " %16s DeAllocate %s\n", time, ptr,
+              -size, space < 0 ? "" : space_name[space], name);
+    if (operation == MEMOP_PUSH_REGION)
+      fprintf(ofile, "%lf PushRegion %s {\n", time, name);
+    if (operation == MEMOP_POP_REGION)
+      fprintf(ofile, "%lf } PopRegion %s\n", time, name);
   }
 };
-

--- a/profiling/memory-events/kp_timer.hpp
+++ b/profiling/memory-events/kp_timer.hpp
@@ -1,46 +1,18 @@
-/*
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
-*/
 
 #ifndef KOKKOS_TIMER_HPP
 #define KOKKOS_TIMER_HPP

--- a/profiling/memory-hwm-mpi/kp_hwm_mpi.cpp
+++ b/profiling/memory-hwm-mpi/kp_hwm_mpi.cpp
@@ -71,7 +71,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
 
   if (world_rank == 0) {
-    printf("KokkosP: Example Library Initialized (sequence is %d, version: %" PRIu64 ")\n", loadSeq, interfaceVer);
+    printf("KokkosP: High Water Mark Library Initialized (sequence is %d, version: %" PRIu64 ")\n", loadSeq, interfaceVer);
   }
 }
 

--- a/profiling/memory-hwm-mpi/kp_hwm_mpi.cpp
+++ b/profiling/memory-hwm-mpi/kp_hwm_mpi.cpp
@@ -25,15 +25,15 @@ static int world_size = 1;
 
 // darwin report rusage.ru_maxrss in bytes
 #if defined(__APPLE__) || defined(__MACH__)
-#    define RU_MAXRSS_UNITS 1024
+#define RU_MAXRSS_UNITS 1024
 #else
-#    define RU_MAXRSS_UNITS 1
+#define RU_MAXRSS_UNITS 1
 #endif
 
 extern "C" void kokkosp_init_library(const int loadSeq,
-  const uint64_t interfaceVer,
-  const uint32_t devInfoCount,
-  void* deviceInfo) {
+                                     const uint64_t interfaceVer,
+                                     const uint32_t devInfoCount,
+                                     void* deviceInfo) {
   int mpi_is_initialized;
   MPI_Initialized(&mpi_is_initialized);
   if (!mpi_is_initialized) {
@@ -45,7 +45,10 @@ extern "C" void kokkosp_init_library(const int loadSeq,
   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
 
   if (world_rank == 0) {
-    printf("KokkosP: High Water Mark Library Initialized (sequence is %d, version: %" PRIu64 ")\n", loadSeq, interfaceVer);
+    printf(
+        "KokkosP: High Water Mark Library Initialized (sequence is %d, "
+        "version: %" PRIu64 ")\n",
+        loadSeq, interfaceVer);
   }
 }
 
@@ -73,10 +76,8 @@ extern "C" void kokkosp_finalize_library() {
   hwm_ave /= world_size;
 
   if (world_rank == 0) {
-    printf("KokkosP: High water mark memory consumption: %ld kB\n",
-      hwm_max);
-    printf("  Max: %ld, Min: %ld, Ave: %ld kB\n",
-      hwm_max,hwm_min,hwm_ave);
+    printf("KokkosP: High water mark memory consumption: %ld kB\n", hwm_max);
+    printf("  Max: %ld, Min: %ld, Ave: %ld kB\n", hwm_max, hwm_min, hwm_ave);
     printf("\n");
   }
 }

--- a/profiling/memory-hwm-mpi/kp_hwm_mpi.cpp
+++ b/profiling/memory-hwm-mpi/kp_hwm_mpi.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 #include <sys/resource.h>
 #include <cstdio>

--- a/profiling/memory-hwm/kp_hwm.cpp
+++ b/profiling/memory-hwm/kp_hwm.cpp
@@ -61,7 +61,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
 	const uint32_t devInfoCount,
 	void* deviceInfo) {
 
-	printf("KokkosP: Example Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
+	printf("KokkosP: High Water Mark Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
 }
 
 // darwin report rusage.ru_maxrss in bytes

--- a/profiling/memory-hwm/kp_hwm.cpp
+++ b/profiling/memory-hwm/kp_hwm.cpp
@@ -31,28 +31,30 @@
 static uint64_t uniqID = 0;
 
 extern "C" void kokkosp_init_library(const int loadSeq,
-	const uint64_t interfaceVer,
-	const uint32_t devInfoCount,
-	void* deviceInfo) {
-
-	printf("KokkosP: High Water Mark Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
+                                     const uint64_t interfaceVer,
+                                     const uint32_t devInfoCount,
+                                     void* deviceInfo) {
+  printf(
+      "KokkosP: High Water Mark Library Initialized (sequence is %d, version: "
+      "%llu)\n",
+      loadSeq, interfaceVer);
 }
 
 // darwin report rusage.ru_maxrss in bytes
 #if defined(__APPLE__) || defined(__MACH__)
-#    define RU_MAXRSS_UNITS 1024
+#define RU_MAXRSS_UNITS 1024
 #else
-#    define RU_MAXRSS_UNITS 1
+#define RU_MAXRSS_UNITS 1
 #endif
 
 extern "C" void kokkosp_finalize_library() {
-	printf("\n");
-	printf("KokkosP: Finalization of profiling library.\n");
+  printf("\n");
+  printf("KokkosP: Finalization of profiling library.\n");
 
-	struct rusage sys_resources;
-	getrusage(RUSAGE_SELF, &sys_resources);
+  struct rusage sys_resources;
+  getrusage(RUSAGE_SELF, &sys_resources);
 
-	printf("KokkosP: High water mark memory consumption: %li kB\n",
-		(long) sys_resources.ru_maxrss * RU_MAXRSS_UNITS);
-	printf("\n");
+  printf("KokkosP: High water mark memory consumption: %li kB\n",
+         (long)sys_resources.ru_maxrss * RU_MAXRSS_UNITS);
+  printf("\n");
 }

--- a/profiling/memory-hwm/kp_hwm.cpp
+++ b/profiling/memory-hwm/kp_hwm.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #include <stdio.h>

--- a/profiling/memory-usage/kp_memory_events.hpp
+++ b/profiling/memory-usage/kp_memory_events.hpp
@@ -1,46 +1,18 @@
-/*
 //@HEADER
 // ************************************************************************
-// 
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
-// 
+//
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact  David Poliakoff (dzpolia@sandia.gov)
-// 
-// ************************************************************************
 //@HEADER
-// */
 
 #define MEMOP_ALLOCATE 1
 #define MEMOP_DEALLOCATE 2

--- a/profiling/memory-usage/kp_memory_events.hpp
+++ b/profiling/memory-usage/kp_memory_events.hpp
@@ -32,28 +32,31 @@ struct EventRecord {
   double time;
   char name[256];
 
-
-  EventRecord(const void* const ptr_, const uint64_t size_, const int operation_,
-              const int space_, const double time_, const char* const name_) {
-    ptr = ptr_;
-    size = size_;
+  EventRecord(const void* const ptr_, const uint64_t size_,
+              const int operation_, const int space_, const double time_,
+              const char* const name_) {
+    ptr       = ptr_;
+    size      = size_;
     operation = operation_;
-    space = space_;
-    time = time_;
-    strncpy(name,name_,256);
+    space     = space_;
+    time      = time_;
+    strncpy(name, name_, 256);
   }
 
   void print_record() const {
-    if(operation == MEMOP_ALLOCATE)
-      printf("%lf %16p %14d %16s Allocate   %s\n",time,ptr,size,space<0?"":space_name[space],name);
-    if(operation == MEMOP_DEALLOCATE)
-      printf("%lf %16p %14d %16s DeAllocate %s\n",time,ptr,-size,space<0?"":space_name[space],name);
+    if (operation == MEMOP_ALLOCATE)
+      printf("%lf %16p %14d %16s Allocate   %s\n", time, ptr, size,
+             space < 0 ? "" : space_name[space], name);
+    if (operation == MEMOP_DEALLOCATE)
+      printf("%lf %16p %14d %16s DeAllocate %s\n", time, ptr, -size,
+             space < 0 ? "" : space_name[space], name);
   }
   void print_record(FILE* ofile) const {
-    if(operation == MEMOP_ALLOCATE)
-      fprintf(ofile,"%lf %16p %14d %16s Allocate   %s\n",time,ptr,size,space<0?"":space_name[space],name);
-    if(operation == MEMOP_DEALLOCATE)
-      fprintf(ofile,"%lf %16p %14d %16s DeAllocate %s\n",time,ptr,-size,space<0?"":space_name[space],name);
+    if (operation == MEMOP_ALLOCATE)
+      fprintf(ofile, "%lf %16p %14d %16s Allocate   %s\n", time, ptr, size,
+              space < 0 ? "" : space_name[space], name);
+    if (operation == MEMOP_DEALLOCATE)
+      fprintf(ofile, "%lf %16p %14d %16s DeAllocate %s\n", time, ptr, -size,
+              space < 0 ? "" : space_name[space], name);
   }
 };
-

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -14,8 +14,7 @@
 //
 //@HEADER
 
-
-#include<cstdio>
+#include <cstdio>
 #include <inttypes.h>
 #include <vector>
 #include <unordered_map>
@@ -29,7 +28,7 @@
 #include "kp_timer.hpp"
 
 int num_spaces;
-std::vector<std::tuple<double,uint64_t,double> > space_size_track[16];
+std::vector<std::tuple<double, uint64_t, double> > space_size_track[16];
 uint64_t space_size[16];
 
 static std::mutex m;
@@ -37,88 +36,92 @@ static std::mutex m;
 Kokkos::Timer timer;
 
 double max_mem_usage() {
-    struct rusage app_info;
-    getrusage(RUSAGE_SELF, &app_info);
-    const double max_rssKB = app_info.ru_maxrss;
-    return max_rssKB*1024;
+  struct rusage app_info;
+  getrusage(RUSAGE_SELF, &app_info);
+  const double max_rssKB = app_info.ru_maxrss;
+  return max_rssKB * 1024;
 }
 
 extern "C" void kokkosp_init_library(const int loadSeq,
-  const uint64_t interfaceVer,
-  const uint32_t devInfoCount,
-  void* deviceInfo) {
-
+                                     const uint64_t interfaceVer,
+                                     const uint32_t devInfoCount,
+                                     void* deviceInfo) {
   num_spaces = 0;
-  for(int i=0; i<16; i++)
-    space_size[i] = 0;
-  
+  for (int i = 0; i < 16; i++) space_size[i] = 0;
+
   timer.reset();
 }
 
 extern "C" void kokkosp_finalize_library() {
-  char* hostname = (char*) malloc(sizeof(char) * 256);
+  char* hostname = (char*)malloc(sizeof(char) * 256);
   gethostname(hostname, 256);
   int pid = getpid();
 
-  for(int s = 0; s<num_spaces; s++) {	
-    char* fileOutput = (char*) malloc(sizeof(char) * 256);
-    sprintf(fileOutput, "%s-%d-%s.memspace_usage", hostname, pid, space_name[s]);
+  for (int s = 0; s < num_spaces; s++) {
+    char* fileOutput = (char*)malloc(sizeof(char) * 256);
+    sprintf(fileOutput, "%s-%d-%s.memspace_usage", hostname, pid,
+            space_name[s]);
 
     FILE* ofile = fopen(fileOutput, "wb");
     free(fileOutput);
 
-    fprintf(ofile,"# Space %s\n",space_name[s]);
-    fprintf(ofile,"# Time(s)  Size(MB)   HighWater(MB)   HighWater-Process(MB)\n");
+    fprintf(ofile, "# Space %s\n", space_name[s]);
+    fprintf(ofile,
+            "# Time(s)  Size(MB)   HighWater(MB)   HighWater-Process(MB)\n");
     uint64_t maxvalue = 0;
-    for(int i=0; i<space_size_track[s].size(); i++) {
-      if(std::get<1>(space_size_track[s][i]) > maxvalue) maxvalue = std::get<1>(space_size_track[s][i]);
-      fprintf(ofile,"%lf %.1lf %.1lf %.1lf\n",
+    for (int i = 0; i < space_size_track[s].size(); i++) {
+      if (std::get<1>(space_size_track[s][i]) > maxvalue)
+        maxvalue = std::get<1>(space_size_track[s][i]);
+      fprintf(ofile, "%lf %.1lf %.1lf %.1lf\n",
               std::get<0>(space_size_track[s][i]),
-              1.0*std::get<1>(space_size_track[s][i])/1024/1024,
-              1.0*maxvalue/1024/1024,
-              1.0*std::get<2>(space_size_track[s][i])/1024/1024);
+              1.0 * std::get<1>(space_size_track[s][i]) / 1024 / 1024,
+              1.0 * maxvalue / 1024 / 1024,
+              1.0 * std::get<2>(space_size_track[s][i]) / 1024 / 1024);
     }
-    fclose(ofile); 
- }
+    fclose(ofile);
+  }
   free(hostname);
 }
 
-extern "C" void kokkosp_allocate_data(const SpaceHandle space, const char* label, const void* const ptr, const uint64_t size) {
+extern "C" void kokkosp_allocate_data(const SpaceHandle space,
+                                      const char* label, const void* const ptr,
+                                      const uint64_t size) {
   std::lock_guard<std::mutex> lock(m);
- 
-  double time = timer.seconds();
-  
-  int space_i = num_spaces;
-  for(int s = 0; s<num_spaces; s++)
-    if(strcmp(space_name[s],space.name)==0)
-      space_i = s;
 
-  if(space_i == num_spaces) {
-    strncpy(space_name[num_spaces],space.name,64);
+  double time = timer.seconds();
+
+  int space_i = num_spaces;
+  for (int s = 0; s < num_spaces; s++)
+    if (strcmp(space_name[s], space.name) == 0) space_i = s;
+
+  if (space_i == num_spaces) {
+    strncpy(space_name[num_spaces], space.name, 64);
     num_spaces++;
   }
   space_size[space_i] += size;
-  space_size_track[space_i].push_back(std::make_tuple(time,space_size[space_i],max_mem_usage()));
+  space_size_track[space_i].push_back(
+      std::make_tuple(time, space_size[space_i], max_mem_usage()));
 }
 
-
-extern "C" void kokkosp_deallocate_data(const SpaceHandle space, const char* label, const void* const ptr, const uint64_t size) {
+extern "C" void kokkosp_deallocate_data(const SpaceHandle space,
+                                        const char* label,
+                                        const void* const ptr,
+                                        const uint64_t size) {
   std::lock_guard<std::mutex> lock(m);
 
   double time = timer.seconds();
 
   int space_i = num_spaces;
-  for(int s = 0; s<num_spaces; s++)
-    if(strcmp(space_name[s],space.name)==0)
-      space_i = s;
+  for (int s = 0; s < num_spaces; s++)
+    if (strcmp(space_name[s], space.name) == 0) space_i = s;
 
-  if(space_i == num_spaces) {
-    strncpy(space_name[num_spaces],space.name,64);
+  if (space_i == num_spaces) {
+    strncpy(space_name[num_spaces], space.name, 64);
     num_spaces++;
   }
-  if(space_size[space_i] >= size) {
+  if (space_size[space_i] >= size) {
     space_size[space_i] -= size;
-    space_size_track[space_i].push_back(std::make_tuple(time,space_size[space_i],max_mem_usage()));
+    space_size_track[space_i].push_back(
+        std::make_tuple(time, space_size[space_i], max_mem_usage()));
   }
 }
-

--- a/profiling/memory-usage/kp_memory_usage.cpp
+++ b/profiling/memory-usage/kp_memory_usage.cpp
@@ -1,46 +1,18 @@
-/*
 //@HEADER
 // ************************************************************************
-// 
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
-// 
+//
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact  David Poliakoff (dzpolia@sandia.gov)
-// 
-// ************************************************************************
 //@HEADER
-// */
 
 
 #include<cstdio>

--- a/profiling/memory-usage/kp_timer.hpp
+++ b/profiling/memory-usage/kp_timer.hpp
@@ -1,46 +1,18 @@
-/*
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
-*/
 
 #ifndef KOKKOS_TIMER_HPP
 #define KOKKOS_TIMER_HPP

--- a/profiling/nvprof-connector/kp_nvprof_connector.cpp
+++ b/profiling/nvprof-connector/kp_nvprof_connector.cpp
@@ -42,6 +42,8 @@
 
 #include <cstdio>
 #include <cstdint>
+#include <vector>
+#include <string>
 
 #include "nvToolsExt.h"
 
@@ -114,3 +116,29 @@ extern "C" void kokkosp_push_profile_region(char* regionName) {
 extern "C" void kokkosp_pop_profile_region() {
   nvtxRangePop();
 }
+
+namespace {
+struct Section {
+        std::string label;
+        nvtxRangeId_t id;
+};
+std::vector<Section> kokkosp_sections;
+}  // namespace
+
+extern "C" void kokkosp_create_profile_section(const char* name,
+                                               uint32_t* sID) {
+        *sID = kokkosp_sections.size();
+        kokkosp_sections.push_back(
+            {std::string(name), static_cast<nvtxRangeId_t>(-1)});
+}
+
+extern "C" void kokkosp_start_profile_section(const uint32_t sID) {
+        auto& section = kokkosp_sections[sID];
+        section.id = nvtxRangeStartA(section.label.c_str());
+}
+
+extern "C" void kokkosp_stop_profile_section(const uint32_t sID) {
+        auto const& section = kokkosp_sections[sID];
+        nvtxRangeEnd(section.id);
+}
+

--- a/profiling/nvprof-connector/kp_nvprof_connector.cpp
+++ b/profiling/nvprof-connector/kp_nvprof_connector.cpp
@@ -40,14 +40,8 @@
 // ************************************************************************
 //@HEADER
 
-#include <stdio.h>
-#include <inttypes.h>
-#include <cstdlib>
-#include <cstring>
-#include <unordered_map>
-#include <stack>
-#include <string>
-#include <iostream>
+#include <cstdio>
+#include <cstdint>
 
 #include "nvToolsExt.h"
 

--- a/profiling/nvprof-connector/kp_nvprof_connector.cpp
+++ b/profiling/nvprof-connector/kp_nvprof_connector.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #include <cstdio>

--- a/profiling/nvprof-connector/kp_nvprof_connector.cpp
+++ b/profiling/nvprof-connector/kp_nvprof_connector.cpp
@@ -21,13 +21,13 @@
 
 #include "nvToolsExt.h"
 
-struct Kokkos_Tools_ToolSettings
-{
+struct Kokkos_Tools_ToolSettings {
   bool requires_global_fencing;
   bool padding[255];
 };
 
-extern "C" void kokkosp_request_tool_settings(const uint32_t, Kokkos_Tools_ToolSettings* settings) {
+extern "C" void kokkosp_request_tool_settings(
+    const uint32_t, Kokkos_Tools_ToolSettings* settings) {
   settings->requires_global_fencing = false;
 }
 
@@ -87,9 +87,7 @@ extern "C" void kokkosp_push_profile_region(char* regionName) {
   nvtxRangePush(regionName);
 }
 
-extern "C" void kokkosp_pop_profile_region() {
-  nvtxRangePop();
-}
+extern "C" void kokkosp_pop_profile_region() { nvtxRangePop(); }
 
 namespace {
 struct Section {
@@ -103,16 +101,15 @@ extern "C" void kokkosp_create_profile_section(const char* name,
                                                uint32_t* sID) {
   *sID = kokkosp_sections.size();
   kokkosp_sections.push_back(
-    {std::string(name), static_cast<nvtxRangeId_t>(-1)});
+      {std::string(name), static_cast<nvtxRangeId_t>(-1)});
 }
 
 extern "C" void kokkosp_start_profile_section(const uint32_t sID) {
   auto& section = kokkosp_sections[sID];
-  section.id = nvtxRangeStartA(section.label.c_str());
+  section.id    = nvtxRangeStartA(section.label.c_str());
 }
 
 extern "C" void kokkosp_stop_profile_section(const uint32_t sID) {
   auto const& section = kokkosp_sections[sID];
   nvtxRangeEnd(section.id);
 }
-

--- a/profiling/nvprof-connector/kp_nvprof_connector.cpp
+++ b/profiling/nvprof-connector/kp_nvprof_connector.cpp
@@ -119,26 +119,26 @@ extern "C" void kokkosp_pop_profile_region() {
 
 namespace {
 struct Section {
-        std::string label;
-        nvtxRangeId_t id;
+  std::string label;
+  nvtxRangeId_t id;
 };
 std::vector<Section> kokkosp_sections;
 }  // namespace
 
 extern "C" void kokkosp_create_profile_section(const char* name,
                                                uint32_t* sID) {
-        *sID = kokkosp_sections.size();
-        kokkosp_sections.push_back(
-            {std::string(name), static_cast<nvtxRangeId_t>(-1)});
+  *sID = kokkosp_sections.size();
+  kokkosp_sections.push_back(
+    {std::string(name), static_cast<nvtxRangeId_t>(-1)});
 }
 
 extern "C" void kokkosp_start_profile_section(const uint32_t sID) {
-        auto& section = kokkosp_sections[sID];
-        section.id = nvtxRangeStartA(section.label.c_str());
+  auto& section = kokkosp_sections[sID];
+  section.id = nvtxRangeStartA(section.label.c_str());
 }
 
 extern "C" void kokkosp_stop_profile_section(const uint32_t sID) {
-        auto const& section = kokkosp_sections[sID];
-        nvtxRangeEnd(section.id);
+  auto const& section = kokkosp_sections[sID];
+  nvtxRangeEnd(section.id);
 }
 

--- a/profiling/nvprof-connector/kp_nvprof_connector_domain.h
+++ b/profiling/nvprof-connector/kp_nvprof_connector_domain.h
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #ifndef _H_KOKKOSP_KERNEL_NVPROF_CONNECTOR_INFO

--- a/profiling/nvprof-connector/kp_nvprof_connector_domain.h
+++ b/profiling/nvprof-connector/kp_nvprof_connector_domain.h
@@ -24,66 +24,55 @@
 #include "nvToolsExt.h"
 
 enum KernelExecutionType {
-	PARALLEL_FOR = 0,
-	PARALLEL_REDUCE = 1,
-	PARALLEL_SCAN = 2
+  PARALLEL_FOR    = 0,
+  PARALLEL_REDUCE = 1,
+  PARALLEL_SCAN   = 2
 };
 
 class KernelNVProfConnectorInfo {
-	public:
-		KernelNVProfConnectorInfo(std::string kName, KernelExecutionType kernelType) {
+ public:
+  KernelNVProfConnectorInfo(std::string kName, KernelExecutionType kernelType) {
+    domainNameHandle = kName;
+    char* domainName = (char*)malloc(sizeof(char*) * (32 + kName.size()));
 
-		  domainNameHandle = kName;
-			char* domainName = (char*) malloc( sizeof(char*) * (32 + kName.size()) );
+    if (kernelType == PARALLEL_FOR) {
+      sprintf(domainName, "ParallelFor.%s", kName.c_str());
+    } else if (kernelType == PARALLEL_REDUCE) {
+      sprintf(domainName, "ParallelReduce.%s", kName.c_str());
+    } else if (kernelType == PARALLEL_SCAN) {
+      sprintf(domainName, "ParallelScan.%s", kName.c_str());
+    } else {
+      sprintf(domainName, "Kernel.%s", kName.c_str());
+    }
 
-			if(kernelType == PARALLEL_FOR) {
-				sprintf(domainName, "ParallelFor.%s", kName.c_str());
-			} else if(kernelType == PARALLEL_REDUCE) {
-				sprintf(domainName, "ParallelReduce.%s", kName.c_str());
-			} else if(kernelType == PARALLEL_SCAN) {
-				sprintf(domainName, "ParallelScan.%s", kName.c_str());
-			} else {
-				sprintf(domainName, "Kernel.%s", kName.c_str());
-			}
+    domain       = nvtxDomainCreateA(domainName);
+    currentRange = 0;
+  }
 
-			domain = nvtxDomainCreateA(domainName);
-			currentRange = 0;
-		}
+  nvtxRangeId_t startRange() {
+    nvtxEventAttributes_t eventAttrib = {0};
+    eventAttrib.version               = NVTX_VERSION;
+    eventAttrib.size                  = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+    eventAttrib.messageType           = NVTX_MESSAGE_TYPE_ASCII;
+    eventAttrib.message.ascii         = "Kernel";
+    currentRange = nvtxDomainRangeStartEx(domain, &eventAttrib);
+    return currentRange;
+  }
 
-		nvtxRangeId_t startRange() {
-		  nvtxEventAttributes_t eventAttrib = {0};
-		  eventAttrib.version = NVTX_VERSION;
-		  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
-		  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
-		  eventAttrib.message.ascii = "Kernel";
-		  currentRange = nvtxDomainRangeStartEx(domain,&eventAttrib);
-		  return currentRange;
-		}
+  nvtxRangeId_t getCurrentRange() { return currentRange; }
 
-		nvtxRangeId_t getCurrentRange() {
-		  return currentRange;
-		}
+  void endRange() { nvtxDomainRangeEnd(domain, currentRange); }
 
-		void endRange() {
-		  nvtxDomainRangeEnd(domain,currentRange);
-		}
+  nvtxDomainHandle_t getDomain() { return domain; }
 
-		nvtxDomainHandle_t getDomain() {
-			return domain;
-		}
+  std::string getDomainNameHandle() { return domainNameHandle; }
 
-		std::string getDomainNameHandle() {
-			return domainNameHandle;
-		}
+  ~KernelNVProfConnectorInfo() { nvtxDomainDestroy(domain); }
 
-		~KernelNVProfConnectorInfo() {
-		  nvtxDomainDestroy(domain);
-		}
-
-	private:
-		std::string domainNameHandle;
-		nvtxRangeId_t currentRange;
-		nvtxDomainHandle_t domain;
+ private:
+  std::string domainNameHandle;
+  nvtxRangeId_t currentRange;
+  nvtxDomainHandle_t domain;
 };
 
 #endif

--- a/profiling/nvprof-focused-connector/kp_nvprof_focused_connector.cpp
+++ b/profiling/nvprof-focused-connector/kp_nvprof_focused_connector.cpp
@@ -25,37 +25,39 @@
 #include "kp_nvprof_focused_connector_domain.h"
 
 static KernelNVProfFocusedConnectorInfo* currentKernel;
-static std::unordered_map<std::string, KernelNVProfFocusedConnectorInfo*> domain_map;
+static std::unordered_map<std::string, KernelNVProfFocusedConnectorInfo*>
+    domain_map;
 static uint64_t nextKernelID;
 
 extern "C" void kokkosp_init_library(const int loadSeq,
-	const uint64_t interfaceVer,
-	const uint32_t devInfoCount,
-	void* deviceInfo) {
+                                     const uint64_t interfaceVer,
+                                     const uint32_t devInfoCount,
+                                     void* deviceInfo) {
+  printf("-----------------------------------------------------------\n");
+  printf(
+      "KokkosP: NVProf Analyzer Focused Connector (sequence is %d, version: "
+      "%llu)\n",
+      loadSeq, interfaceVer);
+  printf("-----------------------------------------------------------\n");
 
-	printf("-----------------------------------------------------------\n");
-	printf("KokkosP: NVProf Analyzer Focused Connector (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
-	printf("-----------------------------------------------------------\n");
-
-	nextKernelID = 0;
+  nextKernelID = 0;
 }
 
-KernelNVProfFocusedConnectorInfo* getFocusedConnectorInfo(const char* name,
-		KernelExecutionType kType) {
+KernelNVProfFocusedConnectorInfo* getFocusedConnectorInfo(
+    const char* name, KernelExecutionType kType) {
+  std::string nameStr(name);
+  auto kDomain  = domain_map.find(nameStr);
+  currentKernel = NULL;
 
-	std::string nameStr(name);
-	auto kDomain = domain_map.find(nameStr);
-	currentKernel = NULL;
+  if (kDomain == domain_map.end()) {
+    currentKernel = new KernelNVProfFocusedConnectorInfo(name, kType);
+    domain_map.insert(std::pair<std::string, KernelNVProfFocusedConnectorInfo*>(
+        nameStr, currentKernel));
+  } else {
+    currentKernel = kDomain->second;
+  }
 
-	if(kDomain == domain_map.end()) {
-		currentKernel = new KernelNVProfFocusedConnectorInfo(name, kType);
-		domain_map.insert(std::pair<std::string, KernelNVProfFocusedConnectorInfo*>(nameStr,
-			currentKernel));
-	} else {
-		currentKernel = kDomain->second;
-	}
-
-	return currentKernel;
+  return currentKernel;
 }
 
 void focusedConnectorExecuteStart() {
@@ -66,45 +68,50 @@ void focusedConnectorExecuteStart() {
 void focusedConnectorExecuteEnd() {
   currentKernel->endRange();
   cudaProfilerStop();
-	currentKernel = NULL;
+  currentKernel = NULL;
 }
 
 extern "C" void kokkosp_finalize_library() {
-	printf("-----------------------------------------------------------\n");
-	printf("KokkosP: Finalization of NVProf Connector. Complete.\n");
-	printf("-----------------------------------------------------------\n");
-
+  printf("-----------------------------------------------------------\n");
+  printf("KokkosP: Finalization of NVProf Connector. Complete.\n");
+  printf("-----------------------------------------------------------\n");
 }
 
-extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = nextKernelID++;
+extern "C" void kokkosp_begin_parallel_for(const char* name,
+                                           const uint32_t devID,
+                                           uint64_t* kID) {
+  *kID = nextKernelID++;
 
-	currentKernel = getFocusedConnectorInfo(name, PARALLEL_FOR);
-	focusedConnectorExecuteStart();
+  currentKernel = getFocusedConnectorInfo(name, PARALLEL_FOR);
+  focusedConnectorExecuteStart();
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
-	focusedConnectorExecuteEnd();
+  focusedConnectorExecuteEnd();
 }
 
-extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = nextKernelID++;
+extern "C" void kokkosp_begin_parallel_scan(const char* name,
+                                            const uint32_t devID,
+                                            uint64_t* kID) {
+  *kID = nextKernelID++;
 
-	currentKernel = getFocusedConnectorInfo(name, PARALLEL_SCAN);
-	focusedConnectorExecuteStart();
+  currentKernel = getFocusedConnectorInfo(name, PARALLEL_SCAN);
+  focusedConnectorExecuteStart();
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
-	focusedConnectorExecuteEnd();
+  focusedConnectorExecuteEnd();
 }
 
-extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = nextKernelID++;
+extern "C" void kokkosp_begin_parallel_reduce(const char* name,
+                                              const uint32_t devID,
+                                              uint64_t* kID) {
+  *kID = nextKernelID++;
 
-	currentKernel = getFocusedConnectorInfo(name, PARALLEL_REDUCE);
- 	focusedConnectorExecuteStart();
+  currentKernel = getFocusedConnectorInfo(name, PARALLEL_REDUCE);
+  focusedConnectorExecuteStart();
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
-	focusedConnectorExecuteEnd();
+  focusedConnectorExecuteEnd();
 }

--- a/profiling/nvprof-focused-connector/kp_nvprof_focused_connector.cpp
+++ b/profiling/nvprof-focused-connector/kp_nvprof_focused_connector.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #include <stdio.h>

--- a/profiling/nvprof-focused-connector/kp_nvprof_focused_connector_domain.h
+++ b/profiling/nvprof-focused-connector/kp_nvprof_focused_connector_domain.h
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #ifndef _H_KOKKOSP_KERNEL_NVPROF_CONNECTOR_INFO

--- a/profiling/nvprof-focused-connector/kp_nvprof_focused_connector_domain.h
+++ b/profiling/nvprof-focused-connector/kp_nvprof_focused_connector_domain.h
@@ -24,66 +24,56 @@
 #include "nvToolsExt.h"
 
 enum KernelExecutionType {
-	PARALLEL_FOR = 0,
-	PARALLEL_REDUCE = 1,
-	PARALLEL_SCAN = 2
+  PARALLEL_FOR    = 0,
+  PARALLEL_REDUCE = 1,
+  PARALLEL_SCAN   = 2
 };
 
 class KernelNVProfFocusedConnectorInfo {
-	public:
-		KernelNVProfFocusedConnectorInfo(std::string kName, KernelExecutionType kernelType) {
+ public:
+  KernelNVProfFocusedConnectorInfo(std::string kName,
+                                   KernelExecutionType kernelType) {
+    domainNameHandle = kName;
+    char* domainName = (char*)malloc(sizeof(char*) * (32 + kName.size()));
 
-		  domainNameHandle = kName;
-			char* domainName = (char*) malloc( sizeof(char*) * (32 + kName.size()) );
+    if (kernelType == PARALLEL_FOR) {
+      sprintf(domainName, "ParallelFor.%s", kName.c_str());
+    } else if (kernelType == PARALLEL_REDUCE) {
+      sprintf(domainName, "ParallelReduce.%s", kName.c_str());
+    } else if (kernelType == PARALLEL_SCAN) {
+      sprintf(domainName, "ParallelScan.%s", kName.c_str());
+    } else {
+      sprintf(domainName, "Kernel.%s", kName.c_str());
+    }
 
-			if(kernelType == PARALLEL_FOR) {
-				sprintf(domainName, "ParallelFor.%s", kName.c_str());
-			} else if(kernelType == PARALLEL_REDUCE) {
-				sprintf(domainName, "ParallelReduce.%s", kName.c_str());
-			} else if(kernelType == PARALLEL_SCAN) {
-				sprintf(domainName, "ParallelScan.%s", kName.c_str());
-			} else {
-				sprintf(domainName, "Kernel.%s", kName.c_str());
-			}
+    domain       = nvtxDomainCreateA(domainName);
+    currentRange = 0;
+  }
 
-			domain = nvtxDomainCreateA(domainName);
-			currentRange = 0;
-		}
+  nvtxRangeId_t startRange() {
+    nvtxEventAttributes_t eventAttrib = {0};
+    eventAttrib.version               = NVTX_VERSION;
+    eventAttrib.size                  = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+    eventAttrib.messageType           = NVTX_MESSAGE_TYPE_ASCII;
+    eventAttrib.message.ascii         = "my range";
+    currentRange = nvtxDomainRangeStartEx(domain, &eventAttrib);
+    return currentRange;
+  }
 
-		nvtxRangeId_t startRange() {
-		  nvtxEventAttributes_t eventAttrib = {0};
-		  eventAttrib.version = NVTX_VERSION;
-		  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
-		  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
-		  eventAttrib.message.ascii = "my range";
-		  currentRange = nvtxDomainRangeStartEx(domain,&eventAttrib);
-		  return currentRange;
-		}
+  nvtxRangeId_t getCurrentRange() { return currentRange; }
 
-		nvtxRangeId_t getCurrentRange() {
-		  return currentRange;
-		}
+  void endRange() { nvtxDomainRangeEnd(domain, currentRange); }
 
-		void endRange() {
-		  nvtxDomainRangeEnd(domain,currentRange);
-		}
+  nvtxDomainHandle_t getDomain() { return domain; }
 
-		nvtxDomainHandle_t getDomain() {
-			return domain;
-		}
+  std::string getDomainNameHandle() { return domainNameHandle; }
 
-		std::string getDomainNameHandle() {
-			return domainNameHandle;
-		}
+  ~KernelNVProfFocusedConnectorInfo() { nvtxDomainDestroy(domain); }
 
-		~KernelNVProfFocusedConnectorInfo() {
-		  nvtxDomainDestroy(domain);
-		}
-
-	private:
-		std::string domainNameHandle;
-		nvtxRangeId_t currentRange;
-		nvtxDomainHandle_t domain;
+ private:
+  std::string domainNameHandle;
+  nvtxRangeId_t currentRange;
+  nvtxDomainHandle_t domain;
 };
 
 #endif

--- a/profiling/papi-connector/kp_papi_connector.cpp
+++ b/profiling/papi-connector/kp_papi_connector.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #include <stdio.h>

--- a/profiling/papi-connector/kp_papi_connector.cpp
+++ b/profiling/papi-connector/kp_papi_connector.cpp
@@ -28,176 +28,158 @@
 #include "kp_papi_connector_domain.h"
 
 extern "C" void kokkosp_init_library(const int loadSeq,
-   const uint64_t interfaceVer,
-   const uint32_t devInfoCount,
-   void* deviceInfo)
-{
+                                     const uint64_t interfaceVer,
+                                     const uint32_t devInfoCount,
+                                     void* deviceInfo) {
+  printf("-----------------------------------------------------------\n");
+  printf("KokkosP: PAPI Connector (sequence is %d, version: %llu)\n", loadSeq,
+         interfaceVer);
+  printf("-----------------------------------------------------------\n");
 
-   printf("-----------------------------------------------------------\n");
-   printf("KokkosP: PAPI Connector (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
-   printf("-----------------------------------------------------------\n");
-
-   /* The following advanced functions of PAPI's high-level API are not part
-    * of the official release. But they might be introduced in later PAPI releases.
-    * PAPI_hl_init is now called from the first PAPI_hl_region_begin call.
-    */
-   //PAPI_hl_init();
-   /* set default values */
-   //PAPI_hl_set_events("perf::TASK-CLOCK,PAPI_TOT_INS,PAPI_TOT_CYC,PAPI_FP_OPS");
+  /* The following advanced functions of PAPI's high-level API are not part
+   * of the official release. But they might be introduced in later PAPI
+   * releases. PAPI_hl_init is now called from the first PAPI_hl_region_begin
+   * call.
+   */
+  // PAPI_hl_init();
+  /* set default values */
+  // PAPI_hl_set_events("perf::TASK-CLOCK,PAPI_TOT_INS,PAPI_TOT_CYC,PAPI_FP_OPS");
 }
 
-extern "C" void kokkosp_finalize_library()
-{
-   /* The following advanced functions of PAPI's high-level API are not part
-    * of the official release. But they might be introduced in later PAPI releases.
-    * PAPI_hl_print_output is registered by the "atexit" function and will be called
-    * at process termination, see http://man7.org/linux/man-pages/man3/atexit.3.html.
-    */
-   //PAPI_hl_print_output();
-   //PAPI_hl_finalize();
+extern "C" void kokkosp_finalize_library() {
+  /* The following advanced functions of PAPI's high-level API are not part
+   * of the official release. But they might be introduced in later PAPI
+   * releases. PAPI_hl_print_output is registered by the "atexit" function and
+   * will be called at process termination, see
+   * http://man7.org/linux/man-pages/man3/atexit.3.html.
+   */
+  // PAPI_hl_print_output();
+  // PAPI_hl_finalize();
 
-   printf("-----------------------------------------------------------\n");
-   printf("KokkosP: Finalization of PAPI Connector. Complete.\n");
-   printf("-----------------------------------------------------------\n");
+  printf("-----------------------------------------------------------\n");
+  printf("KokkosP: Finalization of PAPI Connector. Complete.\n");
+  printf("-----------------------------------------------------------\n");
 }
 
-extern "C" void kokkosp_begin_parallel_for(const char* name, uint32_t devid, uint64_t* kernid)
-{
-   //printf("kokkosp_begin_parallel_for: %s %d\n", name, *kernid);
-   std::stringstream ss;
-   ss << "kokkosp_parallel_for:" << name;
-   parallel_for_name.push(ss.str());
-   PAPI_hl_region_begin(ss.str().c_str());
+extern "C" void kokkosp_begin_parallel_for(const char* name, uint32_t devid,
+                                           uint64_t* kernid) {
+  // printf("kokkosp_begin_parallel_for: %s %d\n", name, *kernid);
+  std::stringstream ss;
+  ss << "kokkosp_parallel_for:" << name;
+  parallel_for_name.push(ss.str());
+  PAPI_hl_region_begin(ss.str().c_str());
 }
-extern "C" void kokkosp_end_parallel_for(uint64_t kernid)
-{
-   //printf("kokkosp_end_parallel_for: %d\n", kernid);
-   if ( parallel_for_name.empty() == false ) {
-      PAPI_hl_region_end(parallel_for_name.top().c_str());
-      parallel_for_name.pop();
-   } else {
-      printf("Begin callback of parallel_for does not exist!\n");
-   }
-}
-
-
-extern "C" void kokkosp_begin_parallel_reduce(const char* name, uint32_t devid, uint64_t* kernid)
-{
-   //printf("kokkosp_begin_parallel_reduce: %s %d\n", name, *kernid);
-   std::stringstream ss;
-   ss << "kokkosp_parallel_reduce:" << name;
-   parallel_reduce_name.push(ss.str());
-   PAPI_hl_region_begin(ss.str().c_str());
-}
-extern "C" void kokkosp_end_parallel_reduce(uint64_t kernid)
-{
-   //printf("kokkosp_end_parallel_reduce: %d\n", kernid);
-   if ( parallel_reduce_name.empty() == false ) {
-      PAPI_hl_region_end(parallel_reduce_name.top().c_str());
-      parallel_reduce_name.pop();
-   } else {
-      printf("Begin callback of parallel_reduce does not exist!\n");
-   }
+extern "C" void kokkosp_end_parallel_for(uint64_t kernid) {
+  // printf("kokkosp_end_parallel_for: %d\n", kernid);
+  if (parallel_for_name.empty() == false) {
+    PAPI_hl_region_end(parallel_for_name.top().c_str());
+    parallel_for_name.pop();
+  } else {
+    printf("Begin callback of parallel_for does not exist!\n");
+  }
 }
 
-
-extern "C" void kokkosp_begin_parallel_scan(const char* name, uint32_t devid, uint64_t* kernid)
-{
-   //printf("kokkosp_begin_parallel_scan: %s %d\n", name, *kernid);
-   std::stringstream ss;
-   ss << "kokkosp_parallel_scan:" << name;
-   parallel_scan_name.push(ss.str());
-   PAPI_hl_region_begin(ss.str().c_str());
+extern "C" void kokkosp_begin_parallel_reduce(const char* name, uint32_t devid,
+                                              uint64_t* kernid) {
+  // printf("kokkosp_begin_parallel_reduce: %s %d\n", name, *kernid);
+  std::stringstream ss;
+  ss << "kokkosp_parallel_reduce:" << name;
+  parallel_reduce_name.push(ss.str());
+  PAPI_hl_region_begin(ss.str().c_str());
 }
-extern "C" void kokkosp_end_parallel_scan(uint64_t kernid)
-{
-   //printf("kokkosp_end_parallel_scan: %d\n", kernid);
-   if ( parallel_scan_name.empty() == false ) {
-      PAPI_hl_region_end(parallel_scan_name.top().c_str());
-      parallel_scan_name.pop();
-   } else {
-      printf("Begin callback of parallel_scan does not exist!\n");
-   }
+extern "C" void kokkosp_end_parallel_reduce(uint64_t kernid) {
+  // printf("kokkosp_end_parallel_reduce: %d\n", kernid);
+  if (parallel_reduce_name.empty() == false) {
+    PAPI_hl_region_end(parallel_reduce_name.top().c_str());
+    parallel_reduce_name.pop();
+  } else {
+    printf("Begin callback of parallel_reduce does not exist!\n");
+  }
 }
 
-
-extern "C" void kokkosp_push_profile_region(const char* name)
-{
-   std::stringstream ss;
-   ss << "kokkosp_profile_region:" << name;
-   region_name.push(ss.str());
-   PAPI_hl_region_begin(ss.str().c_str());
+extern "C" void kokkosp_begin_parallel_scan(const char* name, uint32_t devid,
+                                            uint64_t* kernid) {
+  // printf("kokkosp_begin_parallel_scan: %s %d\n", name, *kernid);
+  std::stringstream ss;
+  ss << "kokkosp_parallel_scan:" << name;
+  parallel_scan_name.push(ss.str());
+  PAPI_hl_region_begin(ss.str().c_str());
+}
+extern "C" void kokkosp_end_parallel_scan(uint64_t kernid) {
+  // printf("kokkosp_end_parallel_scan: %d\n", kernid);
+  if (parallel_scan_name.empty() == false) {
+    PAPI_hl_region_end(parallel_scan_name.top().c_str());
+    parallel_scan_name.pop();
+  } else {
+    printf("Begin callback of parallel_scan does not exist!\n");
+  }
 }
 
-extern "C" void kokkosp_profile_event( const char* name )
-{
-   if ( region_name.empty() == false ) {
-      PAPI_hl_read(region_name.top().c_str());
-   }
+extern "C" void kokkosp_push_profile_region(const char* name) {
+  std::stringstream ss;
+  ss << "kokkosp_profile_region:" << name;
+  region_name.push(ss.str());
+  PAPI_hl_region_begin(ss.str().c_str());
 }
 
-extern "C" void kokkosp_pop_profile_region()
-{
-   if ( region_name.empty() == false ) {
-      PAPI_hl_region_end(region_name.top().c_str());
-      region_name.pop();
-   } else {
-      printf("Region does not exist!\n");
-   }
+extern "C" void kokkosp_profile_event(const char* name) {
+  if (region_name.empty() == false) {
+    PAPI_hl_read(region_name.top().c_str());
+  }
 }
 
-
-extern "C" void kokkosp_begin_deep_copy(
-   SpaceHandle dst_handle, const char* dst_name, const void* dst_ptr,
-   SpaceHandle src_handle, const char* src_name, const void* src_ptr,
-   uint64_t size)
-{
-   PAPI_hl_region_begin("kokkosp_deep_copy");
-}
-extern "C" void kokkosp_end_deep_copy()
-{
-   PAPI_hl_region_end("kokkosp_deep_copy");
+extern "C" void kokkosp_pop_profile_region() {
+  if (region_name.empty() == false) {
+    PAPI_hl_region_end(region_name.top().c_str());
+    region_name.pop();
+  } else {
+    printf("Region does not exist!\n");
+  }
 }
 
-
-extern "C" void kokkosp_create_profile_section( const char* name, uint32_t* sec_id)
-{
-   //printf("kokkosp_create_profile_section: %s %d\n", name, *sec_id);
-   profile_section.insert( std::pair<uint32_t, std::string>(*sec_id, name) );
+extern "C" void kokkosp_begin_deep_copy(SpaceHandle dst_handle,
+                                        const char* dst_name,
+                                        const void* dst_ptr,
+                                        SpaceHandle src_handle,
+                                        const char* src_name,
+                                        const void* src_ptr, uint64_t size) {
+  PAPI_hl_region_begin("kokkosp_deep_copy");
 }
-extern "C" void kokkosp_destroy_profile_section( uint32_t sec_id)
-{
-   //printf("kokkosp_destroy_profile_section: %d\n", sec_id);
-   std::map<uint32_t, std::string>::iterator it;
-   it = profile_section.find(sec_id);
-   if ( it != profile_section.end() )
-      profile_section.erase(it);
+extern "C" void kokkosp_end_deep_copy() {
+  PAPI_hl_region_end("kokkosp_deep_copy");
 }
 
-
-extern "C" void kokkosp_start_profile_section( uint32_t sec_id)
-{
-   //printf("kokkosp_start_profile_section: %d\n", sec_id);
-   std::map<uint32_t, std::string>::iterator it;
-   it = profile_section.find(sec_id);
-   if ( it != profile_section.end() ) {
-      std::stringstream ss;
-      ss << it->second << ":" << sec_id;
-      region_name.push(ss.str());
-      PAPI_hl_region_begin(ss.str().c_str());
-   }
-
+extern "C" void kokkosp_create_profile_section(const char* name,
+                                               uint32_t* sec_id) {
+  // printf("kokkosp_create_profile_section: %s %d\n", name, *sec_id);
+  profile_section.insert(std::pair<uint32_t, std::string>(*sec_id, name));
 }
-extern "C" void kokkosp_stop_profile_section( uint32_t sec_id)
-{
-   //printf("kokkosp_stop_profile_section: %d\n", sec_id);
-   std::map<uint32_t, std::string>::iterator it;
-   it = profile_section.find(sec_id);
-   if ( it != profile_section.end() ) {
-      std::stringstream ss;
-      ss << it->second << ":" << sec_id;
-      region_name.push(ss.str());
-      PAPI_hl_region_end(ss.str().c_str());
-   }
+extern "C" void kokkosp_destroy_profile_section(uint32_t sec_id) {
+  // printf("kokkosp_destroy_profile_section: %d\n", sec_id);
+  std::map<uint32_t, std::string>::iterator it;
+  it = profile_section.find(sec_id);
+  if (it != profile_section.end()) profile_section.erase(it);
 }
 
+extern "C" void kokkosp_start_profile_section(uint32_t sec_id) {
+  // printf("kokkosp_start_profile_section: %d\n", sec_id);
+  std::map<uint32_t, std::string>::iterator it;
+  it = profile_section.find(sec_id);
+  if (it != profile_section.end()) {
+    std::stringstream ss;
+    ss << it->second << ":" << sec_id;
+    region_name.push(ss.str());
+    PAPI_hl_region_begin(ss.str().c_str());
+  }
+}
+extern "C" void kokkosp_stop_profile_section(uint32_t sec_id) {
+  // printf("kokkosp_stop_profile_section: %d\n", sec_id);
+  std::map<uint32_t, std::string>::iterator it;
+  it = profile_section.find(sec_id);
+  if (it != profile_section.end()) {
+    std::stringstream ss;
+    ss << it->second << ":" << sec_id;
+    region_name.push(ss.str());
+    PAPI_hl_region_end(ss.str().c_str());
+  }
+}

--- a/profiling/papi-connector/kp_papi_connector_domain.h
+++ b/profiling/papi-connector/kp_papi_connector_domain.h
@@ -24,7 +24,7 @@
 #include "papi.h"
 
 struct SpaceHandle {
-   char name[64];
+  char name[64];
 };
 
 /* stack for parallel_for */
@@ -41,6 +41,5 @@ std::stack<std::string> region_name;
 
 /* map of profile sections */
 std::map<uint32_t, std::string> profile_section;
-
 
 #endif

--- a/profiling/papi-connector/kp_papi_connector_domain.h
+++ b/profiling/papi-connector/kp_papi_connector_domain.h
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #ifndef _H_KOKKOSP_KERNEL_PAPI_CONNECTOR_INFO

--- a/profiling/roctx-connector/Makefile
+++ b/profiling/roctx-connector/Makefile
@@ -1,5 +1,5 @@
 CXX=g++
-CXXFLAGS=-O3 -g -I$(ROCM_PATH)/roctracer/include
+CXXFLAGS=-O3 -g -I$(ROCM_PATH)/include/roctracer
 LDFLAGS=-L$(ROCM_PATH)/lib
 LIBS=-lroctx64
 SHARED_CXXFLAGS=-shared -fPIC

--- a/profiling/roctx-connector/kp_roctx_connector.cpp
+++ b/profiling/roctx-connector/kp_roctx_connector.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #include <roctx.h>

--- a/profiling/roctx-connector/kp_roctx_connector.cpp
+++ b/profiling/roctx-connector/kp_roctx_connector.cpp
@@ -23,110 +23,104 @@
 
 namespace {
 struct Section {
-        std::string label;
-        roctx_range_id_t id;
+  std::string label;
+  roctx_range_id_t id;
 };
 std::vector<Section> kokkosp_sections;
 }  // namespace
 
-
-struct Kokkos_Tools_ToolSettings
-{
-        bool requires_global_fencing;
-        bool padding[255];
+struct Kokkos_Tools_ToolSettings {
+  bool requires_global_fencing;
+  bool padding[255];
 };
 
-extern "C" void kokkosp_request_tool_settings(const uint32_t,
-                                              Kokkos_Tools_ToolSettings* settings) {
-        settings->requires_global_fencing = false;
+extern "C" void kokkosp_request_tool_settings(
+    const uint32_t, Kokkos_Tools_ToolSettings* settings) {
+  settings->requires_global_fencing = false;
 }
 
 extern "C" void kokkosp_init_library(const int loadSeq,
                                      const uint64_t interfaceVer,
                                      const uint32_t /*devInfoCount*/,
                                      void* /*deviceInfo*/) {
-        std::cout
-            << "-----------------------------------------------------------\n"
+  std::cout << "-----------------------------------------------------------\n"
             << "KokkosP: ROC Tracer Connector (sequence is " << loadSeq
             << ", version: " << interfaceVer << ")\n"
             << "-----------------------------------------------------------\n";
 
-        roctxMark("Kokkos::Initialization Complete");
+  roctxMark("Kokkos::Initialization Complete");
 }
 
 extern "C" void kokkosp_finalize_library() {
-        std::cout << R"(
+  std::cout << R"(
 -----------------------------------------------------------
 KokkosP: Finalization of ROC Tracer Connector. Complete.
 -----------------------------------------------------------
 )";
 
-        roctxMark("Kokkos::Finalization Complete");
+  roctxMark("Kokkos::Finalization Complete");
 }
 
 extern "C" void kokkosp_begin_parallel_for(const char* name,
                                            const uint32_t /*devID*/,
                                            uint64_t* /*kID*/) {
-        roctxRangePush(name);
+  roctxRangePush(name);
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t /*kID*/) {
-        roctxRangePop();
+  roctxRangePop();
 }
 
 extern "C" void kokkosp_begin_parallel_scan(const char* name,
                                             const uint32_t /*devID*/,
                                             uint64_t* /*kID*/) {
-        roctxRangePush(name);
+  roctxRangePush(name);
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t /*kID*/) {
-        roctxRangePop();
+  roctxRangePop();
 }
 
 extern "C" void kokkosp_begin_parallel_reduce(const char* name,
                                               const uint32_t /*devID*/,
                                               uint64_t* /*kID*/) {
-        roctxRangePush(name);
+  roctxRangePush(name);
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t /*kID*/) {
-        roctxRangePop();
+  roctxRangePop();
 }
 
 extern "C" void kokkosp_push_profile_region(char* name) {
-        roctxRangePush(name);
+  roctxRangePush(name);
 }
 
 extern "C" void kokkosp_pop_profile_region() { roctxRangePop(); }
 
 extern "C" void kokkosp_create_profile_section(const char* name,
                                                uint32_t* sID) {
-        *sID = kokkosp_sections.size();
-        kokkosp_sections.push_back(
-            {std::string(name), static_cast<roctx_range_id_t>(-1)});
+  *sID = kokkosp_sections.size();
+  kokkosp_sections.push_back(
+      {std::string(name), static_cast<roctx_range_id_t>(-1)});
 }
 
 extern "C" void kokkosp_start_profile_section(const uint32_t sID) {
-        auto& section = kokkosp_sections[sID];
-        section.id = roctxRangeStart(section.label.c_str());
+  auto& section = kokkosp_sections[sID];
+  section.id    = roctxRangeStart(section.label.c_str());
 }
 
 extern "C" void kokkosp_stop_profile_section(const uint32_t sID) {
-        auto const& section = kokkosp_sections[sID];
-        roctxRangeStop(section.id);
+  auto const& section = kokkosp_sections[sID];
+  roctxRangeStop(section.id);
 }
 
 extern "C" void kokkosp_destroy_profile_section(const uint32_t sID) {
-        // do nothing
+  // do nothing
 }
 
-extern "C" void kokkosp_begin_fence(const char* name,
-		                    const uint32_t /*devID*/,
-		                    uint64_t* fID) {
-        *fID = roctxRangeStart(name);
+extern "C" void kokkosp_begin_fence(const char* name, const uint32_t /*devID*/,
+                                    uint64_t* fID) {
+  *fID = roctxRangeStart(name);
 }
 
-extern "C" void kokkosp_end_fence(const uint64_t fID) {
-        roctxRangeStop(fID);
-}
+extern "C" void kokkosp_end_fence(const uint64_t fID) { roctxRangeStop(fID); }

--- a/profiling/roctx-connector/kp_roctx_connector.cpp
+++ b/profiling/roctx-connector/kp_roctx_connector.cpp
@@ -55,6 +55,18 @@ struct Section {
 std::vector<Section> kokkosp_sections;
 }  // namespace
 
+
+struct Kokkos_Tools_ToolSettings
+{
+        bool requires_global_fencing;
+        bool padding[255];
+};
+
+extern "C" void kokkosp_request_tool_settings(const uint32_t,
+                                              Kokkos_Tools_ToolSettings* settings) {
+        settings->requires_global_fencing = false;
+}
+
 extern "C" void kokkosp_init_library(const int loadSeq,
                                      const uint64_t interfaceVer,
                                      const uint32_t /*devInfoCount*/,

--- a/profiling/roctx-connector/kp_roctx_connector.cpp
+++ b/profiling/roctx-connector/kp_roctx_connector.cpp
@@ -146,3 +146,13 @@ extern "C" void kokkosp_stop_profile_section(const uint32_t sID) {
 extern "C" void kokkosp_destroy_profile_section(const uint32_t sID) {
         // do nothing
 }
+
+extern "C" void kokkosp_begin_fence(const char* name,
+		                    const uint32_t /*devID*/,
+		                    uint64_t* fID) {
+        *fID = roctxRangeStart(name);
+}
+
+extern "C" void kokkosp_end_fence(const uint64_t fID) {
+        roctxRangeStop(fID);
+}

--- a/profiling/simple-kernel-timer-json/kp_kernel_info.h
+++ b/profiling/simple-kernel-timer-json/kp_kernel_info.h
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #ifndef _H_KOKKOSP_KERNEL_INFO

--- a/profiling/simple-kernel-timer-json/kp_kernel_info.h
+++ b/profiling/simple-kernel-timer-json/kp_kernel_info.h
@@ -27,178 +27,163 @@
 
 #if defined(HAVE_GCC_ABI_DEMANGLE)
 #include <cxxabi.h>
-#endif // HAVE_GCC_ABI_DEMANGLE
+#endif  // HAVE_GCC_ABI_DEMANGLE
 
-char* demangleName(char* kernelName)
-{
+char* demangleName(char* kernelName) {
 #if defined(HAVE_GCC_ABI_DEMANGLE)
-	int status = -1;
-	char* demangledKernelName = abi::__cxa_demangle(kernelName, NULL, NULL, &status);
-	if (status==0) {
-		free(kernelName);
-		kernelName = demangledKernelName;
-	}
-#endif // HAVE_GCC_ABI_DEMANGLE
-	return kernelName;
+  int status = -1;
+  char* demangledKernelName =
+      abi::__cxa_demangle(kernelName, NULL, NULL, &status);
+  if (status == 0) {
+    free(kernelName);
+    kernelName = demangledKernelName;
+  }
+#endif  // HAVE_GCC_ABI_DEMANGLE
+  return kernelName;
 }
 
 double seconds() {
-	struct timeval now;
-	gettimeofday(&now, NULL);
+  struct timeval now;
+  gettimeofday(&now, NULL);
 
-	return (double) (now.tv_sec + (now.tv_usec * 1.0e-6));
+  return (double)(now.tv_sec + (now.tv_usec * 1.0e-6));
 }
 
 enum KernelExecutionType {
-	PARALLEL_FOR = 0,
-	PARALLEL_REDUCE = 1,
-	PARALLEL_SCAN = 2
+  PARALLEL_FOR    = 0,
+  PARALLEL_REDUCE = 1,
+  PARALLEL_SCAN   = 2
 };
 
 class KernelPerformanceInfo {
-	public:
-		KernelPerformanceInfo(std::string kName, KernelExecutionType kernelType) :
-			kType(kernelType) {
+ public:
+  KernelPerformanceInfo(std::string kName, KernelExecutionType kernelType)
+      : kType(kernelType) {
+    kernelName = (char*)malloc(sizeof(char) * (kName.size() + 1));
+    regionName = "";
+    strcpy(kernelName, kName.c_str());
 
-			kernelName = (char*) malloc(sizeof(char) * (kName.size() + 1));
-			regionName = "";
-			strcpy(kernelName, kName.c_str());
+    callCount = 0;
+    time      = 0;
+  }
 
-			callCount = 0;
-			time = 0;
-		}
+  ~KernelPerformanceInfo() { free(kernelName); }
 
-		~KernelPerformanceInfo() {
-			free(kernelName);
-		}
+  KernelExecutionType getKernelType() { return kType; }
 
-		KernelExecutionType getKernelType() {
-			return kType;
-		}
+  void incrementCount() { callCount++; }
 
-		void incrementCount() {
-			callCount++;
-		}
+  void addTime(double t) {
+    time += t;
+    timeSq += (t * t);
+  }
 
-		void addTime(double t) {
-			time   += t;
-			timeSq += (t*t);
-		}
+  void addFromTimer() {
+    addTime(seconds() - startTime);
 
-		void addFromTimer() {
-			addTime(seconds() - startTime);
+    incrementCount();
+  }
 
-			incrementCount();
-		}
+  void startTimer() { startTime = seconds(); }
 
-		void startTimer() {
-			startTime = seconds();
-		}
+  uint64_t getCallCount() { return callCount; }
 
-		uint64_t getCallCount() {
-			return callCount;
-		}
+  double getTime() { return time; }
 
-		double getTime() {
-			return time;
-		}
+  double getTimeSq() { return timeSq; }
 
-		double getTimeSq() {
-			return timeSq;
-		}
+  char* getName() { return kernelName; }
 
-		char* getName() {
-			return kernelName;
-		}
+  void addCallCount(const uint64_t newCalls) { callCount += newCalls; }
 
-		void addCallCount(const uint64_t newCalls) {
-			callCount += newCalls;
-		}
+  bool readFromFile(FILE* input) {
+    uint32_t recordLen   = 0;
+    uint32_t actual_read = fread(&recordLen, sizeof(recordLen), 1, input);
+    if (actual_read != 1) return false;
 
-		bool readFromFile(FILE* input) {
-			uint32_t recordLen = 0;
-			uint32_t actual_read = fread(&recordLen, sizeof(recordLen), 1, input);
-	                if(actual_read != 1) return false;
+    char* entry = (char*)malloc(recordLen);
+    fread(entry, recordLen, 1, input);
 
-			char* entry = (char*) malloc(recordLen);
-                        fread(entry, recordLen, 1, input);
+    uint32_t nextIndex = 0;
+    uint32_t kernelNameLength;
+    copy((char*)&kernelNameLength, &entry[nextIndex], sizeof(kernelNameLength));
+    nextIndex += sizeof(kernelNameLength);
 
-			uint32_t nextIndex = 0;
-			uint32_t kernelNameLength;
-			copy((char*) &kernelNameLength, &entry[nextIndex], sizeof(kernelNameLength));
-			nextIndex += sizeof(kernelNameLength);
+    if (strlen(kernelName) > 0) {
+      free(kernelName);
+    }
 
-			if(strlen(kernelName) > 0) {
-				free(kernelName);
-			}
+    kernelName = (char*)malloc(sizeof(char) * (kernelNameLength + 1));
+    copy(kernelName, &entry[nextIndex], kernelNameLength);
+    kernelName[kernelNameLength] = '\0';
 
-			kernelName = (char*) malloc( sizeof(char) * (kernelNameLength + 1));
-			copy(kernelName, &entry[nextIndex], kernelNameLength);
-			kernelName[kernelNameLength] = '\0';
+    kernelName = demangleName(kernelName);
 
-			kernelName = demangleName(kernelName);
+    nextIndex += kernelNameLength;
 
-			nextIndex += kernelNameLength;
+    copy((char*)&callCount, &entry[nextIndex], sizeof(callCount));
+    nextIndex += sizeof(callCount);
 
-			copy((char*) &callCount, &entry[nextIndex], sizeof(callCount));
-			nextIndex += sizeof(callCount);
+    copy((char*)&time, &entry[nextIndex], sizeof(time));
+    nextIndex += sizeof(time);
 
-			copy((char*) &time, &entry[nextIndex], sizeof(time));
-			nextIndex += sizeof(time);
+    copy((char*)&timeSq, &entry[nextIndex], sizeof(timeSq));
+    nextIndex += sizeof(timeSq);
 
-			copy((char*) &timeSq, &entry[nextIndex], sizeof(timeSq));
-			nextIndex += sizeof(timeSq);
+    uint32_t kernelT = 0;
+    copy((char*)&kernelT, &entry[nextIndex], sizeof(kernelT));
+    nextIndex += sizeof(kernelT);
 
-			uint32_t kernelT = 0;
-			copy((char*) &kernelT, &entry[nextIndex], sizeof(kernelT));
-			nextIndex += sizeof(kernelT);
+    if (kernelT == 0) {
+      kType = PARALLEL_FOR;
+    } else if (kernelT == 1) {
+      kType = PARALLEL_REDUCE;
+    } else if (kernelT == 2) {
+      kType = PARALLEL_SCAN;
+    }
 
-			if(kernelT == 0) {
-				kType = PARALLEL_FOR;
-			} else if(kernelT == 1) {
-				kType = PARALLEL_REDUCE;
-			} else if(kernelT == 2) {
-				kType = PARALLEL_SCAN;
-			}
+    free(entry);
+    return true;
+  }
 
-			free(entry);
-                        return true;
-		}
+  void writeToFile(FILE* output, char* indent) {
+    fprintf(output, "%s{\n", indent);
 
-		void writeToFile(FILE* output, char* indent) {
-			fprintf(output, "%s{\n", indent);
+    char* indentBuffer = (char*)malloc(sizeof(char) * 256);
+    sprintf(indentBuffer, "%s    ", indent);
 
-			char* indentBuffer = (char*) malloc( sizeof(char) * 256 );
-			sprintf(indentBuffer, "%s    ", indent);
+    fprintf(output, "%s\"kernel-name\"    : \"%s\",\n", indentBuffer,
+            kernelName);
+    fprintf(output, "%s\"region\"         : \"%s\",\n", indentBuffer,
+            regionName);
+    fprintf(output, "%s\"call-count\"     : %lu,\n", indentBuffer, callCount);
+    fprintf(output, "%s\"total-time\"     : %f,\n", indentBuffer, time);
+    fprintf(output, "%s\"time-per-call\"  : %16.8f,\n", indentBuffer,
+            (time / static_cast<double>(
+                        std::max(static_cast<uint64_t>(1), callCount))));
+    fprintf(
+        output, "%s\"kernel-type\"    : \"%s\"\n", indentBuffer,
+        (kType == PARALLEL_FOR)
+            ? "PARALLEL-FOR"
+            : (kType == PARALLEL_REDUCE) ? "PARALLEL-REDUCE" : "PARALLEL-SCAN");
 
-			fprintf(output, "%s\"kernel-name\"    : \"%s\",\n", indentBuffer, kernelName);
-			fprintf(output, "%s\"region\"         : \"%s\",\n", indentBuffer, regionName);
-			fprintf(output, "%s\"call-count\"     : %lu,\n", indentBuffer, callCount);
-			fprintf(output, "%s\"total-time\"     : %f,\n", indentBuffer, time);
-			fprintf(output, "%s\"time-per-call\"  : %16.8f,\n", indentBuffer, (time /
-				static_cast<double>(std::max(
-					static_cast<uint64_t>(1), callCount))));
-			fprintf(output, "%s\"kernel-type\"    : \"%s\"\n", indentBuffer,
-				(kType == PARALLEL_FOR) ? "PARALLEL-FOR" :
-				(kType == PARALLEL_REDUCE) ? "PARALLEL-REDUCE" : "PARALLEL-SCAN");
+    fprintf(output, "%s}", indent);
+  }
 
-			fprintf(output, "%s}", indent);
-		}
+ private:
+  void copy(char* dest, const char* src, uint32_t len) {
+    for (uint32_t i = 0; i < len; i++) {
+      dest[i] = src[i];
+    }
+  }
 
-	private:
-		void copy(char* dest, const char* src, uint32_t len) {
-			for(uint32_t i = 0; i < len; i++) {
-				dest[i] = src[i];
-			}
-		}
-
-		char* kernelName;
-		char* regionName;
-		uint64_t callCount;
-		double time;
-		double timeSq;
-		double startTime;
-		KernelExecutionType kType;
+  char* kernelName;
+  char* regionName;
+  uint64_t callCount;
+  double time;
+  double timeSq;
+  double startTime;
+  KernelExecutionType kType;
 };
 
 #endif

--- a/profiling/simple-kernel-timer-json/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer-json/kp_kernel_timer.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #include <stdio.h>

--- a/profiling/simple-kernel-timer-json/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer-json/kp_kernel_timer.cpp
@@ -28,8 +28,9 @@
 #include <unistd.h>
 #include "kp_kernel_info.h"
 
-bool compareKernelPerformanceInfo(KernelPerformanceInfo* left, KernelPerformanceInfo* right) {
-	return left->getTime() > right->getTime();
+bool compareKernelPerformanceInfo(KernelPerformanceInfo* left,
+                                  KernelPerformanceInfo* right) {
+  return left->getTime() > right->getTime();
 };
 
 static uint64_t uniqID = 0;
@@ -41,137 +42,151 @@ static char* outputDelimiter;
 #define MAX_STACK_SIZE 128
 
 void increment_counter(const char* name, KernelExecutionType kType) {
-	std::string nameStr(name);
+  std::string nameStr(name);
 
-	if(count_map.find(name) == count_map.end()) {
-		KernelPerformanceInfo* info = new KernelPerformanceInfo(nameStr, kType);
-		count_map.insert(std::pair<std::string, KernelPerformanceInfo*>(nameStr, info));
+  if (count_map.find(name) == count_map.end()) {
+    KernelPerformanceInfo* info = new KernelPerformanceInfo(nameStr, kType);
+    count_map.insert(
+        std::pair<std::string, KernelPerformanceInfo*>(nameStr, info));
 
-		currentEntry = info;
-	} else {
-		currentEntry = count_map[nameStr];
-	}
+    currentEntry = info;
+  } else {
+    currentEntry = count_map[nameStr];
+  }
 
-	currentEntry->startTimer();
+  currentEntry->startTimer();
 }
 
 extern "C" void kokkosp_init_library(const int loadSeq,
-	const uint64_t interfaceVer,
-	const uint32_t devInfoCount,
-	void* deviceInfo) {
+                                     const uint64_t interfaceVer,
+                                     const uint32_t devInfoCount,
+                                     void* deviceInfo) {
+  const char* output_delim_env = getenv("KOKKOSP_OUTPUT_DELIM");
+  if (NULL == output_delim_env) {
+    outputDelimiter = (char*)malloc(sizeof(char) * 2);
+    sprintf(outputDelimiter, "%c", ' ');
+  } else {
+    outputDelimiter =
+        (char*)malloc(sizeof(char) * (strlen(output_delim_env) + 1));
+    sprintf(outputDelimiter, "%s", output_delim_env);
+  }
 
-	const char* output_delim_env = getenv("KOKKOSP_OUTPUT_DELIM");
-	if(NULL == output_delim_env) {
-		outputDelimiter = (char*) malloc(sizeof(char) * 2);
-		sprintf(outputDelimiter, "%c", ' ');
-	} else {
-		outputDelimiter = (char*) malloc(sizeof(char) * (strlen(output_delim_env) + 1));
-		sprintf(outputDelimiter, "%s", output_delim_env);
-	}
+  printf(
+      "KokkosP: LDMS JSON Connector Initialized (sequence is %d, version: "
+      "%llu)\n",
+      loadSeq, interfaceVer);
 
-	printf("KokkosP: LDMS JSON Connector Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
-
-	initTime = seconds();
+  initTime = seconds();
 }
 
 extern "C" void kokkosp_finalize_library() {
-	double finishTime = seconds();
-	double kernelTimes = 0;
-	
-	char* mpi_rank = getenv("OMPI_COMM_WORLD_RANK");
-	
-	char* hostname = (char*) malloc(sizeof(char) * 256);
-	gethostname(hostname, 256);
-	
-	char* fileOutput = (char*) malloc(sizeof(char) * 256);
-	sprintf(fileOutput, "%s-%d-%s.json", hostname, (int) getpid(),
-		(NULL == mpi_rank) ? "0" : mpi_rank);
-	
-	free(hostname);
-	FILE* output_data = fopen(fileOutput, "w");
+  double finishTime  = seconds();
+  double kernelTimes = 0;
 
-	const double totalExecuteTime = (finishTime - initTime);
-	std::vector<KernelPerformanceInfo*> kernelList;
-	
-	for(auto kernel_itr = count_map.begin(); kernel_itr != count_map.end(); kernel_itr++) {
-		kernelList.push_back(kernel_itr->second);
-		kernelTimes += kernel_itr->second->getTime();
-	}
+  char* mpi_rank = getenv("OMPI_COMM_WORLD_RANK");
 
-	std::sort(kernelList.begin(), kernelList.end(), compareKernelPerformanceInfo);
+  char* hostname = (char*)malloc(sizeof(char) * 256);
+  gethostname(hostname, 256);
 
-	fprintf(output_data, "{\n\"kokkos-kernel-data\" : {\n");
-	fprintf(output_data, "    \"mpi-rank\"               : %s,\n", 
-		(NULL == mpi_rank) ? "0" : mpi_rank);
-	fprintf(output_data, "    \"total-app-time\"         : %10.3f,\n", totalExecuteTime);
-	fprintf(output_data, "    \"total-kernel-times\"     : %10.3f,\n", kernelTimes);
-	fprintf(output_data, "    \"total-non-kernel-times\" : %10.3f,\n", (totalExecuteTime - kernelTimes));
-	
-	const double percentKokkos = (kernelTimes / totalExecuteTime) * 100.0;
-	fprintf(output_data, "    \"percent-in-kernels\"     : %6.2f,\n", percentKokkos);
-	fprintf(output_data, "    \"unique-kernel-calls\"    : %22lu,\n", (uint64_t) count_map.size());
-	fprintf(output_data, "\n");
-	
-	fprintf(output_data, "    \"kernel-perf-info\"       : [\n");
-	
-	#define KERNEL_INFO_INDENT "       "
-	
-        bool print_comma = false;
-	for(auto const& kernel : count_map) {
-                if (print_comma)
-			fprintf(output_data, ",\n");
-		kernel.second->writeToFile(output_data, KERNEL_INFO_INDENT);
-		print_comma = true;
-	}
+  char* fileOutput = (char*)malloc(sizeof(char) * 256);
+  sprintf(fileOutput, "%s-%d-%s.json", hostname, (int)getpid(),
+          (NULL == mpi_rank) ? "0" : mpi_rank);
 
-	fprintf(output_data, "\n");
-	fprintf(output_data, "    ]\n");
-	fprintf(output_data, "}\n}");
-	fclose(output_data);
+  free(hostname);
+  FILE* output_data = fopen(fileOutput, "w");
+
+  const double totalExecuteTime = (finishTime - initTime);
+  std::vector<KernelPerformanceInfo*> kernelList;
+
+  for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
+       kernel_itr++) {
+    kernelList.push_back(kernel_itr->second);
+    kernelTimes += kernel_itr->second->getTime();
+  }
+
+  std::sort(kernelList.begin(), kernelList.end(), compareKernelPerformanceInfo);
+
+  fprintf(output_data, "{\n\"kokkos-kernel-data\" : {\n");
+  fprintf(output_data, "    \"mpi-rank\"               : %s,\n",
+          (NULL == mpi_rank) ? "0" : mpi_rank);
+  fprintf(output_data, "    \"total-app-time\"         : %10.3f,\n",
+          totalExecuteTime);
+  fprintf(output_data, "    \"total-kernel-times\"     : %10.3f,\n",
+          kernelTimes);
+  fprintf(output_data, "    \"total-non-kernel-times\" : %10.3f,\n",
+          (totalExecuteTime - kernelTimes));
+
+  const double percentKokkos = (kernelTimes / totalExecuteTime) * 100.0;
+  fprintf(output_data, "    \"percent-in-kernels\"     : %6.2f,\n",
+          percentKokkos);
+  fprintf(output_data, "    \"unique-kernel-calls\"    : %22lu,\n",
+          (uint64_t)count_map.size());
+  fprintf(output_data, "\n");
+
+  fprintf(output_data, "    \"kernel-perf-info\"       : [\n");
+
+#define KERNEL_INFO_INDENT "       "
+
+  bool print_comma = false;
+  for (auto const& kernel : count_map) {
+    if (print_comma) fprintf(output_data, ",\n");
+    kernel.second->writeToFile(output_data, KERNEL_INFO_INDENT);
+    print_comma = true;
+  }
+
+  fprintf(output_data, "\n");
+  fprintf(output_data, "    ]\n");
+  fprintf(output_data, "}\n}");
+  fclose(output_data);
 }
 
-extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = uniqID++;
+extern "C" void kokkosp_begin_parallel_for(const char* name,
+                                           const uint32_t devID,
+                                           uint64_t* kID) {
+  *kID = uniqID++;
 
-	if( (NULL == name) || (strcmp("", name) == 0) ) {
-		fprintf(stderr, "Error: kernel is empty\n");
-		exit(-1);
-	}
+  if ((NULL == name) || (strcmp("", name) == 0)) {
+    fprintf(stderr, "Error: kernel is empty\n");
+    exit(-1);
+  }
 
-	increment_counter(name, PARALLEL_FOR);
+  increment_counter(name, PARALLEL_FOR);
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
-	currentEntry->addFromTimer();
+  currentEntry->addFromTimer();
 }
 
-extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = uniqID++;
+extern "C" void kokkosp_begin_parallel_scan(const char* name,
+                                            const uint32_t devID,
+                                            uint64_t* kID) {
+  *kID = uniqID++;
 
-	if( (NULL == name) || (strcmp("", name) == 0) ) {
-		fprintf(stderr, "Error: kernel is empty\n");
-		exit(-1);
-	}
+  if ((NULL == name) || (strcmp("", name) == 0)) {
+    fprintf(stderr, "Error: kernel is empty\n");
+    exit(-1);
+  }
 
-	increment_counter(name, PARALLEL_SCAN);
+  increment_counter(name, PARALLEL_SCAN);
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
-	currentEntry->addFromTimer();
+  currentEntry->addFromTimer();
 }
 
-extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = uniqID++;
+extern "C" void kokkosp_begin_parallel_reduce(const char* name,
+                                              const uint32_t devID,
+                                              uint64_t* kID) {
+  *kID = uniqID++;
 
-	if( (NULL == name) || (strcmp("", name) == 0) ) {
-		fprintf(stderr, "Error: kernel is empty\n");
-		exit(-1);
-	}
+  if ((NULL == name) || (strcmp("", name) == 0)) {
+    fprintf(stderr, "Error: kernel is empty\n");
+    exit(-1);
+  }
 
-	increment_counter(name, PARALLEL_REDUCE);
+  increment_counter(name, PARALLEL_REDUCE);
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
-	currentEntry->addFromTimer();
+  currentEntry->addFromTimer();
 }
-

--- a/profiling/simple-kernel-timer/kp_json_writer.cpp
+++ b/profiling/simple-kernel-timer/kp_json_writer.cpp
@@ -1,46 +1,20 @@
-// clang-format off
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
+// clang-format off
 #include <stdio.h>
 #include <cinttypes>
 #include <cstdlib>

--- a/profiling/simple-kernel-timer/kp_json_writer.cpp
+++ b/profiling/simple-kernel-timer/kp_json_writer.cpp
@@ -28,35 +28,30 @@
 
 // clang-format on
 bool is_region(KernelPerformanceInfo const& kp) {
-        return kp.getKernelType() == REGION;
+  return kp.getKernelType() == REGION;
 }
 
 inline std::string to_string(KernelExecutionType t) {
-        switch (t) {
-                case PARALLEL_FOR:
-                        return "\"PARALLEL_FOR\"";
-                case PARALLEL_REDUCE:
-                        return "\"PARALLEL_REDUCE\"";
-                case PARALLEL_SCAN:
-                        return "\"PARALLEL_SCAN\"";
-                case REGION:
-                        return "\"REGION\"";
-                default:
-                        throw t;
-        }
+  switch (t) {
+    case PARALLEL_FOR: return "\"PARALLEL_FOR\"";
+    case PARALLEL_REDUCE: return "\"PARALLEL_REDUCE\"";
+    case PARALLEL_SCAN: return "\"PARALLEL_SCAN\"";
+    case REGION: return "\"REGION\"";
+    default: throw t;
+  }
 }
 
 inline void write_json(std::ostream& os, KernelPerformanceInfo const& kp,
                        std::string indent = "") {
-        os << indent << "{\n";
-        os << indent << "  \"kernel-name\": \"" << kp.getName() << "\",\n";
-        os << indent << "  \"call-count\": " << kp.getCallCount() << ",\n";
-        os << indent << "  \"total-time\": " << kp.getTime() << ",\n";
-        os << indent << "  \"time-per-call\": "
-           << kp.getTime() / std::max((uint64_t)1, kp.getCallCount()) << ",\n";
-        os << indent << "  \"kernel-type\": " << to_string(kp.getKernelType())
-           << '\n';
-        os << indent << '}';
+  os << indent << "{\n";
+  os << indent << "  \"kernel-name\": \"" << kp.getName() << "\",\n";
+  os << indent << "  \"call-count\": " << kp.getCallCount() << ",\n";
+  os << indent << "  \"total-time\": " << kp.getTime() << ",\n";
+  os << indent << "  \"time-per-call\": "
+     << kp.getTime() / std::max((uint64_t)1, kp.getCallCount()) << ",\n";
+  os << indent << "  \"kernel-type\": " << to_string(kp.getKernelType())
+     << '\n';
+  os << indent << '}';
 }
 // clang-format off
 
@@ -142,49 +137,49 @@ int main(int argc, char* argv[]) {
     }
 	}
 
-        // clang-format on
-        // std::string filename = "test.json";
-        // std::ofstream fout(filename);
-        auto& fout = std::cout;
+  // clang-format on
+  // std::string filename = "test.json";
+  // std::ofstream fout(filename);
+  auto& fout = std::cout;
 
-        fout << "{\n";
+  fout << "{\n";
 
-        fout << "  \"total-app-time\" : " << totalExecuteTime << ",\n";
-        fout << "  \"total-kernel-time\" : " << totalKernelsTime << ",\n";
-        fout << "  \"total-non-kernel-time\" : "
-             << totalExecuteTime - totalKernelsTime << ",\n";
-        fout << "  \"percent-in-kernels\" : "
-             << 100. * totalKernelsTime / totalExecuteTime << ",\n";
-        fout << "  \"unique-kernel-calls\" : " << totalKernelsCalls << ",\n";
+  fout << "  \"total-app-time\" : " << totalExecuteTime << ",\n";
+  fout << "  \"total-kernel-time\" : " << totalKernelsTime << ",\n";
+  fout << "  \"total-non-kernel-time\" : "
+       << totalExecuteTime - totalKernelsTime << ",\n";
+  fout << "  \"percent-in-kernels\" : "
+       << 100. * totalKernelsTime / totalExecuteTime << ",\n";
+  fout << "  \"unique-kernel-calls\" : " << totalKernelsCalls << ",\n";
 
-        fout << "  \"region-data\" : [\n";
-        {
-                bool add_comma = false;
-                for (auto const& kp : kernelInfo) {
-                        if (!is_region(*kp)) continue;
-                        if (add_comma) fout << ",\n";
-                        add_comma = true;
-                        write_json(fout, *kp, "    ");
-                }
-                fout << '\n';
-        }
-        fout << "  ],\n";
+  fout << "  \"region-data\" : [\n";
+  {
+    bool add_comma = false;
+    for (auto const& kp : kernelInfo) {
+      if (!is_region(*kp)) continue;
+      if (add_comma) fout << ",\n";
+      add_comma = true;
+      write_json(fout, *kp, "    ");
+    }
+    fout << '\n';
+  }
+  fout << "  ],\n";
 
-        fout << "  \"kernel-data\" : [\n";
-        {
-                bool add_comma = false;
-                for (auto const& kp : kernelInfo) {
-                        if (is_region(*kp)) continue;
-                        if (add_comma) fout << ",\n";
-                        add_comma = true;
-                        write_json(fout, *kp, "    ");
-                }
-                fout << '\n';
-        }
-        fout << "  ]\n";
+  fout << "  \"kernel-data\" : [\n";
+  {
+    bool add_comma = false;
+    for (auto const& kp : kernelInfo) {
+      if (is_region(*kp)) continue;
+      if (add_comma) fout << ",\n";
+      add_comma = true;
+      write_json(fout, *kp, "    ");
+    }
+    fout << '\n';
+  }
+  fout << "  ]\n";
 
-        fout << "}\n";
-        // clang-format off
+  fout << "}\n";
+  // clang-format off
 
 	return 0;
 

--- a/profiling/simple-kernel-timer/kp_kernel_info.h
+++ b/profiling/simple-kernel-timer/kp_kernel_info.h
@@ -28,197 +28,174 @@
 
 #if defined(HAVE_GCC_ABI_DEMANGLE)
 #include <cxxabi.h>
-#endif // HAVE_GCC_ABI_DEMANGLE
+#endif  // HAVE_GCC_ABI_DEMANGLE
 
-char* demangleName(char* kernelName)
-{
+char* demangleName(char* kernelName) {
 #if defined(HAVE_GCC_ABI_DEMANGLE)
-	int status = -1;
-	char* demangledKernelName = abi::__cxa_demangle(kernelName, NULL, NULL, &status);
-	if (status==0) {
-		free(kernelName);
-		kernelName = demangledKernelName;
-	}
-#endif // HAVE_GCC_ABI_DEMANGLE
-	return kernelName;
+  int status = -1;
+  char* demangledKernelName =
+      abi::__cxa_demangle(kernelName, NULL, NULL, &status);
+  if (status == 0) {
+    free(kernelName);
+    kernelName = demangledKernelName;
+  }
+#endif  // HAVE_GCC_ABI_DEMANGLE
+  return kernelName;
 }
 
 double seconds() {
-	struct timeval now;
-	gettimeofday(&now, NULL);
+  struct timeval now;
+  gettimeofday(&now, NULL);
 
-	return (double) (now.tv_sec + (now.tv_usec * 1.0e-6));
+  return (double)(now.tv_sec + (now.tv_usec * 1.0e-6));
 }
 
 enum KernelExecutionType {
-	PARALLEL_FOR = 0,
-	PARALLEL_REDUCE = 1,
-	PARALLEL_SCAN = 2,
-        REGION = 3
+  PARALLEL_FOR    = 0,
+  PARALLEL_REDUCE = 1,
+  PARALLEL_SCAN   = 2,
+  REGION          = 3
 };
 
 class KernelPerformanceInfo {
-	public:
-		KernelPerformanceInfo(std::string kName, KernelExecutionType kernelType) :
-			kType(kernelType) {
+ public:
+  KernelPerformanceInfo(std::string kName, KernelExecutionType kernelType)
+      : kType(kernelType) {
+    kernelName = (char*)malloc(sizeof(char) * (kName.size() + 1));
+    strcpy(kernelName, kName.c_str());
 
-			kernelName = (char*) malloc(sizeof(char) * (kName.size() + 1));
-			strcpy(kernelName, kName.c_str());
+    callCount = 0;
+    time      = 0;
+  }
 
-			callCount = 0;
-			time = 0;
-		}
+  ~KernelPerformanceInfo() { free(kernelName); }
 
-		~KernelPerformanceInfo() {
-			free(kernelName);
-		}
+  KernelExecutionType getKernelType() const { return kType; }
 
-		KernelExecutionType getKernelType() const {
-			return kType;
-		}
+  void incrementCount() { callCount++; }
 
-		void incrementCount() {
-			callCount++;
-		}
+  void addTime(double t) {
+    time += t;
+    timeSq += (t * t);
+  }
 
-		void addTime(double t) {
-			time   += t;
-			timeSq += (t*t);
-		}
+  void addFromTimer() {
+    addTime(seconds() - startTime);
 
-		void addFromTimer() {
-			addTime(seconds() - startTime);
+    incrementCount();
+  }
 
-			incrementCount();
-		}
+  void startTimer() { startTime = seconds(); }
 
-		void startTimer() {
-			startTime = seconds();
-		}
+  uint64_t getCallCount() const { return callCount; }
 
-		uint64_t getCallCount() const {
-			return callCount;
-		}
+  double getTime() const { return time; }
 
-		double getTime() const {
-			return time;
-		}
+  double getTimeSq() { return timeSq; }
 
-		double getTimeSq() {
-			return timeSq;
-		}
+  char* getName() const { return kernelName; }
 
-		char* getName() const {
-			return kernelName;
-		}
+  void addCallCount(const uint64_t newCalls) { callCount += newCalls; }
 
-		void addCallCount(const uint64_t newCalls) {
-			callCount += newCalls;
-		}
+  bool readFromFile(FILE* input) {
+    uint32_t recordLen   = 0;
+    uint32_t actual_read = fread(&recordLen, sizeof(recordLen), 1, input);
+    if (actual_read != 1) return false;
 
-		bool readFromFile(FILE* input) {
-			uint32_t recordLen = 0;
-			uint32_t actual_read = fread(&recordLen, sizeof(recordLen), 1, input);
-	                if(actual_read != 1) return false;
+    char* entry = (char*)malloc(recordLen);
+    fread(entry, recordLen, 1, input);
 
-			char* entry = (char*) malloc(recordLen);
-                        fread(entry, recordLen, 1, input);
+    uint32_t nextIndex = 0;
+    uint32_t kernelNameLength;
+    copy((char*)&kernelNameLength, &entry[nextIndex], sizeof(kernelNameLength));
+    nextIndex += sizeof(kernelNameLength);
 
-			uint32_t nextIndex = 0;
-			uint32_t kernelNameLength;
-			copy((char*) &kernelNameLength, &entry[nextIndex], sizeof(kernelNameLength));
-			nextIndex += sizeof(kernelNameLength);
+    if (strlen(kernelName) > 0) {
+      free(kernelName);
+    }
 
-			if(strlen(kernelName) > 0) {
-				free(kernelName);
-			}
+    kernelName = (char*)malloc(sizeof(char) * (kernelNameLength + 1));
+    copy(kernelName, &entry[nextIndex], kernelNameLength);
+    kernelName[kernelNameLength] = '\0';
 
-			kernelName = (char*) malloc( sizeof(char) * (kernelNameLength + 1));
-			copy(kernelName, &entry[nextIndex], kernelNameLength);
-			kernelName[kernelNameLength] = '\0';
+    kernelName = demangleName(kernelName);
 
-			kernelName = demangleName(kernelName);
+    nextIndex += kernelNameLength;
 
-			nextIndex += kernelNameLength;
+    copy((char*)&callCount, &entry[nextIndex], sizeof(callCount));
+    nextIndex += sizeof(callCount);
 
-			copy((char*) &callCount, &entry[nextIndex], sizeof(callCount));
-			nextIndex += sizeof(callCount);
+    copy((char*)&time, &entry[nextIndex], sizeof(time));
+    nextIndex += sizeof(time);
 
-			copy((char*) &time, &entry[nextIndex], sizeof(time));
-			nextIndex += sizeof(time);
+    copy((char*)&timeSq, &entry[nextIndex], sizeof(timeSq));
+    nextIndex += sizeof(timeSq);
 
-			copy((char*) &timeSq, &entry[nextIndex], sizeof(timeSq));
-			nextIndex += sizeof(timeSq);
+    uint32_t kernelT = 0;
+    copy((char*)&kernelT, &entry[nextIndex], sizeof(kernelT));
+    nextIndex += sizeof(kernelT);
 
-			uint32_t kernelT = 0;
-			copy((char*) &kernelT, &entry[nextIndex], sizeof(kernelT));
-			nextIndex += sizeof(kernelT);
+    if (kernelT == 0) {
+      kType = PARALLEL_FOR;
+    } else if (kernelT == 1) {
+      kType = PARALLEL_REDUCE;
+    } else if (kernelT == 2) {
+      kType = PARALLEL_SCAN;
+    } else if (kernelT == 3) {
+      kType = REGION;
+    }
 
-			if(kernelT == 0) {
-				kType = PARALLEL_FOR;
-			} else if(kernelT == 1) {
-				kType = PARALLEL_REDUCE;
-			} else if(kernelT == 2) {
-				kType = PARALLEL_SCAN;
-			} else if(kernelT == 3) {
-        kType = REGION;
-      }
+    free(entry);
+    return true;
+  }
 
-			free(entry);
-                        return true;
-		}
+  void writeToFile(FILE* output) {
+    const uint32_t kernelNameLen = (uint32_t)strlen(kernelName);
 
-		void writeToFile(FILE* output) {
-			const uint32_t kernelNameLen = (uint32_t) strlen(kernelName);
+    const uint32_t recordLen = sizeof(uint32_t) + sizeof(char) * kernelNameLen +
+                               sizeof(uint64_t) + sizeof(double) +
+                               sizeof(double) + sizeof(uint32_t);
 
-			const uint32_t recordLen =
-				sizeof(uint32_t) +
-				sizeof(char) * kernelNameLen +
-				sizeof(uint64_t) +
-				sizeof(double) +
-				sizeof(double) +
-				sizeof(uint32_t);
+    uint32_t nextIndex = 0;
+    char* entry        = (char*)malloc(recordLen);
 
-			uint32_t nextIndex = 0;
-			char* entry = (char*) malloc(recordLen);
+    copy(&entry[nextIndex], (char*)&kernelNameLen, sizeof(kernelNameLen));
+    nextIndex += sizeof(kernelNameLen);
 
-			copy(&entry[nextIndex], (char*) &kernelNameLen, sizeof(kernelNameLen));
-			nextIndex += sizeof(kernelNameLen);
+    copy(&entry[nextIndex], kernelName, kernelNameLen);
+    nextIndex += kernelNameLen;
 
-			copy(&entry[nextIndex], kernelName, kernelNameLen);
-			nextIndex += kernelNameLen;
+    copy(&entry[nextIndex], (char*)&callCount, sizeof(callCount));
+    nextIndex += sizeof(callCount);
 
-			copy(&entry[nextIndex], (char*) &callCount, sizeof(callCount));
-			nextIndex += sizeof(callCount);
+    copy(&entry[nextIndex], (char*)&time, sizeof(time));
+    nextIndex += sizeof(time);
 
-			copy(&entry[nextIndex], (char*) &time, sizeof(time));
-			nextIndex += sizeof(time);
+    copy(&entry[nextIndex], (char*)&timeSq, sizeof(timeSq));
+    nextIndex += sizeof(timeSq);
 
-			copy(&entry[nextIndex], (char*) &timeSq, sizeof(timeSq));
-			nextIndex += sizeof(timeSq);
+    uint32_t kernelTypeOutput = (uint32_t)kType;
+    copy(&entry[nextIndex], (char*)&kernelTypeOutput, sizeof(kernelTypeOutput));
+    nextIndex += sizeof(kernelTypeOutput);
 
-			uint32_t kernelTypeOutput = (uint32_t) kType;
-			copy(&entry[nextIndex], (char*) &kernelTypeOutput, sizeof(kernelTypeOutput));
-			nextIndex += sizeof(kernelTypeOutput);
+    fwrite(&recordLen, sizeof(uint32_t), 1, output);
+    fwrite(entry, recordLen, 1, output);
+    free(entry);
+  }
 
-			fwrite(&recordLen, sizeof(uint32_t), 1, output);
-			fwrite(entry, recordLen, 1, output);
-			free(entry);
-		}
+ private:
+  void copy(char* dest, const char* src, uint32_t len) {
+    for (uint32_t i = 0; i < len; i++) {
+      dest[i] = src[i];
+    }
+  }
 
-	private:
-		void copy(char* dest, const char* src, uint32_t len) {
-			for(uint32_t i = 0; i < len; i++) {
-				dest[i] = src[i];
-			}
-		}
-
-		char* kernelName;
-		uint64_t callCount;
-		double time;
-		double timeSq;
-		double startTime;
-		KernelExecutionType kType;
+  char* kernelName;
+  uint64_t callCount;
+  double time;
+  double timeSq;
+  double startTime;
+  KernelExecutionType kType;
 };
 
 #endif

--- a/profiling/simple-kernel-timer/kp_kernel_info.h
+++ b/profiling/simple-kernel-timer/kp_kernel_info.h
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #ifndef _H_KOKKOSP_KERNEL_INFO

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #include <stdio.h>

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -29,8 +29,9 @@
 #include <unistd.h>
 #include "kp_kernel_info.h"
 
-bool compareKernelPerformanceInfo(KernelPerformanceInfo* left, KernelPerformanceInfo* right) {
-	return left->getTime() > right->getTime();
+bool compareKernelPerformanceInfo(KernelPerformanceInfo* left,
+                                  KernelPerformanceInfo* right) {
+  return left->getTime() > right->getTime();
 };
 
 static uint64_t uniqID = 0;
@@ -44,276 +45,286 @@ static KernelPerformanceInfo* regions[512];
 #define MAX_STACK_SIZE 128
 
 void increment_counter(const char* name, KernelExecutionType kType) {
-	std::string nameStr(name);
+  std::string nameStr(name);
 
-	if(count_map.find(name) == count_map.end()) {
-		KernelPerformanceInfo* info = new KernelPerformanceInfo(nameStr, kType);
-		count_map.insert(std::pair<std::string, KernelPerformanceInfo*>(nameStr, info));
+  if (count_map.find(name) == count_map.end()) {
+    KernelPerformanceInfo* info = new KernelPerformanceInfo(nameStr, kType);
+    count_map.insert(
+        std::pair<std::string, KernelPerformanceInfo*>(nameStr, info));
 
-		currentEntry = info;
-	} else {
-		currentEntry = count_map[nameStr];
-	}
+    currentEntry = info;
+  } else {
+    currentEntry = count_map[nameStr];
+  }
 
-	currentEntry->startTimer();
+  currentEntry->startTimer();
 }
 
 void increment_counter_region(const char* name, KernelExecutionType kType) {
-        std::string nameStr(name);
+  std::string nameStr(name);
 
-        if(count_map.find(name) == count_map.end()) {
-                KernelPerformanceInfo* info = new KernelPerformanceInfo(nameStr, kType);
-                count_map.insert(std::pair<std::string, KernelPerformanceInfo*>(nameStr, info));
+  if (count_map.find(name) == count_map.end()) {
+    KernelPerformanceInfo* info = new KernelPerformanceInfo(nameStr, kType);
+    count_map.insert(
+        std::pair<std::string, KernelPerformanceInfo*>(nameStr, info));
 
-                regions[current_region_level] = info;
-        } else {
-                regions[current_region_level] = count_map[nameStr];
-        }
+    regions[current_region_level] = info;
+  } else {
+    regions[current_region_level] = count_map[nameStr];
+  }
 
-        regions[current_region_level]->startTimer();
-        current_region_level++;
+  regions[current_region_level]->startTimer();
+  current_region_level++;
 }
 
 extern "C" void kokkosp_init_library(const int loadSeq,
-	const uint64_t interfaceVer,
-	const uint32_t devInfoCount,
-	void* deviceInfo) {
+                                     const uint64_t interfaceVer,
+                                     const uint32_t devInfoCount,
+                                     void* deviceInfo) {
+  const char* output_delim_env = getenv("KOKKOSP_OUTPUT_DELIM");
+  if (NULL == output_delim_env) {
+    outputDelimiter = (char*)malloc(sizeof(char) * 2);
+    sprintf(outputDelimiter, "%c", ' ');
+  } else {
+    outputDelimiter =
+        (char*)malloc(sizeof(char) * (strlen(output_delim_env) + 1));
+    sprintf(outputDelimiter, "%s", output_delim_env);
+  }
 
-	const char* output_delim_env = getenv("KOKKOSP_OUTPUT_DELIM");
-	if(NULL == output_delim_env) {
-		outputDelimiter = (char*) malloc(sizeof(char) * 2);
-		sprintf(outputDelimiter, "%c", ' ');
-	} else {
-		outputDelimiter = (char*) malloc(sizeof(char) * (strlen(output_delim_env) + 1));
-		sprintf(outputDelimiter, "%s", output_delim_env);
-	}
+  // initialize regions to 0s so we know if there is an object there
+  memset(&regions[0], 0, 512 * sizeof(KernelPerformanceInfo*));
 
-	// initialize regions to 0s so we know if there is an object there
-	memset(&regions[0], 0, 512 * sizeof(KernelPerformanceInfo*));
+  printf(
+      "KokkosP: Simple Kernel Timer Library Initialized (sequence is %d, "
+      "version: %llu)\n",
+      loadSeq, interfaceVer);
 
-	printf("KokkosP: Simple Kernel Timer Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
-
-	initTime = seconds();
+  initTime = seconds();
 }
 
 extern "C" void kokkosp_finalize_library() {
-	double finishTime = seconds();
-	double kernelTimes = 0;
+  double finishTime  = seconds();
+  double kernelTimes = 0;
 
-	char* hostname = (char*) malloc(sizeof(char) * 256);
-	gethostname(hostname, 256);
+  char* hostname = (char*)malloc(sizeof(char) * 256);
+  gethostname(hostname, 256);
 
-	char* fileOutput = (char*) malloc(sizeof(char) * 256);
-	sprintf(fileOutput, "%s-%d.dat", hostname, (int) getpid());
+  char* fileOutput = (char*)malloc(sizeof(char) * 256);
+  sprintf(fileOutput, "%s-%d.dat", hostname, (int)getpid());
 
-	free(hostname);
-	FILE* output_data = fopen(fileOutput, "wb");
+  free(hostname);
+  FILE* output_data = fopen(fileOutput, "wb");
 
-	const double totalExecuteTime = (finishTime - initTime);
-	fwrite(&totalExecuteTime, sizeof(totalExecuteTime), 1, output_data);
+  const double totalExecuteTime = (finishTime - initTime);
+  fwrite(&totalExecuteTime, sizeof(totalExecuteTime), 1, output_data);
 
-	std::vector<KernelPerformanceInfo*> kernelList;
+  std::vector<KernelPerformanceInfo*> kernelList;
 
-	for(auto kernel_itr = count_map.begin(); kernel_itr != count_map.end(); kernel_itr++) {
-		kernel_itr->second->writeToFile(output_data);
-	}
+  for (auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
+       kernel_itr++) {
+    kernel_itr->second->writeToFile(output_data);
+  }
 
-	fclose(output_data);
+  fclose(output_data);
 
-	char currentwd[256];
+  char currentwd[256];
   getcwd(currentwd, 256);
   printf("KokkosP: Kernel timing written to %s/%s \n", currentwd, fileOutput);
 
-	/*printf("\n");
-	printf("======================================================================\n");
-	printf("KokkosP: Finalization of Profiling Library\n");
-	printf("KokkosP: Executed a total of %llu kernels\n", uniqID);
+  /*printf("\n");
+  printf("======================================================================\n");
+  printf("KokkosP: Finalization of Profiling Library\n");
+  printf("KokkosP: Executed a total of %llu kernels\n", uniqID);
 
-	std::vector<KernelPerformanceInfo*> kernelList;
+  std::vector<KernelPerformanceInfo*> kernelList;
 
-	for(auto kernel_itr = count_map.begin(); kernel_itr != count_map.end(); kernel_itr++) {
-		kernelList.push_back(kernel_itr->second);
-		kernelTimes += kernel_itr->second->getTime();
-	}
+  for(auto kernel_itr = count_map.begin(); kernel_itr != count_map.end();
+  kernel_itr++) { kernelList.push_back(kernel_itr->second); kernelTimes +=
+  kernel_itr->second->getTime();
+  }
 
-	std::sort(kernelList.begin(), kernelList.end(), compareKernelPerformanceInfo);
-	const double totalExecuteTime = (finishTime - initTime);
+  std::sort(kernelList.begin(), kernelList.end(), compareKernelPerformanceInfo);
+  const double totalExecuteTime = (finishTime - initTime);
 
-	if(0 == strcmp(outputDelimiter, " ")) {
-		printf("KokkosP: %100s %14s %14s %6s %6s %14s %4s\n", "Kernel", "Calls",
-			"s/Total", "\%/Ko", "\%/Tot", "s/Call", "Type");
-	} else {
-		printf("KokkosP: %s%s%s%s%s%s%s%s%s%s%s%s%s\n",
-			"Kernel",
-			outputDelimiter,
-			"Calls",
-			outputDelimiter,
-			"s/Total",
-			outputDelimiter,
-			"\%/Ko",
-			outputDelimiter,
-			"\%/Tot",
-			outputDelimiter,
-			"s/Call",
-			outputDelimiter,
-			"Type");
-	}
+  if(0 == strcmp(outputDelimiter, " ")) {
+          printf("KokkosP: %100s %14s %14s %6s %6s %14s %4s\n", "Kernel",
+  "Calls", "s/Total", "\%/Ko", "\%/Tot", "s/Call", "Type"); } else {
+          printf("KokkosP: %s%s%s%s%s%s%s%s%s%s%s%s%s\n",
+                  "Kernel",
+                  outputDelimiter,
+                  "Calls",
+                  outputDelimiter,
+                  "s/Total",
+                  outputDelimiter,
+                  "\%/Ko",
+                  outputDelimiter,
+                  "\%/Tot",
+                  outputDelimiter,
+                  "s/Call",
+                  outputDelimiter,
+                  "Type");
+  }
 
-	for(auto kernel_itr = kernelList.begin(); kernel_itr != kernelList.end(); kernel_itr++) {
-		KernelPerformanceInfo* kernelInfo = *kernel_itr;
+  for(auto kernel_itr = kernelList.begin(); kernel_itr != kernelList.end();
+  kernel_itr++) { KernelPerformanceInfo* kernelInfo = *kernel_itr;
 
-		const uint64_t kCallCount = kernelInfo->getCallCount();
-		const double   kTime      = kernelInfo->getTime();
-		const double   kTimeMean  = kTime / (double) kCallCount;
+          const uint64_t kCallCount = kernelInfo->getCallCount();
+          const double   kTime      = kernelInfo->getTime();
+          const double   kTimeMean  = kTime / (double) kCallCount;
 
-		const std::string& kName   = kernelInfo->getName();
-		char* kType = const_cast<char*>("");
+          const std::string& kName   = kernelInfo->getName();
+          char* kType = const_cast<char*>("");
 
-		switch(kernelInfo->getKernelType()) {
-		case PARALLEL_FOR:
-			kType = const_cast<char*>("PFOR"); break;
-		case PARALLEL_SCAN:
-			kType = const_cast<char*>("SCAN"); break;
-		case PARALLEL_REDUCE:
-			kType = const_cast<char*>("RDCE"); break;
-                case REGION
-                        kType = const_cast<char*>("REGI"); break;
-		}
+          switch(kernelInfo->getKernelType()) {
+          case PARALLEL_FOR:
+                  kType = const_cast<char*>("PFOR"); break;
+          case PARALLEL_SCAN:
+                  kType = const_cast<char*>("SCAN"); break;
+          case PARALLEL_REDUCE:
+                  kType = const_cast<char*>("RDCE"); break;
+          case REGION
+                  kType = const_cast<char*>("REGI"); break;
+          }
 
-		int demangleStatus;
-		char* finalDemangle = abi::__cxa_demangle(kName.c_str(), 0, 0, &demangleStatus);
+          int demangleStatus;
+          char* finalDemangle = abi::__cxa_demangle(kName.c_str(), 0, 0,
+  &demangleStatus);
 
-		if(0 == strcmp(outputDelimiter, " ")) {
-			printf("KokkosP: %s%s%14llu%s%14.5f%s%6.2f%s%6.2f%s%14.5f%s%4s\n",
-				(0 == demangleStatus) ? finalDemangle : kName.c_str(),
-				outputDelimiter,
-				kCallCount,
-				outputDelimiter,
-				kTime,
-				outputDelimiter,
-				(kTime / kernelTimes) * 100.0,
-				outputDelimiter,
-				(kTime / totalExecuteTime) * 100.0,
-				outputDelimiter,
-				kTimeMean,
-				outputDelimiter,
-				kType
-				);
-		} else {
-			printf("KokkosP: %s%s%llu%s%f%s%f%s%f%s%f%s%s\n",
-				(0 == demangleStatus) ? finalDemangle : kName.c_str(),
-				outputDelimiter,
-				kCallCount,
-				outputDelimiter,
-				kTime,
-				outputDelimiter,
-				(kTime / kernelTimes) * 100.0,
-				outputDelimiter,
-				(kTime / totalExecuteTime) * 100.0,
-				outputDelimiter,
-				kTimeMean,
-				outputDelimiter,
-				kType
-				);
-		}
-	}
+          if(0 == strcmp(outputDelimiter, " ")) {
+                  printf("KokkosP:
+  %s%s%14llu%s%14.5f%s%6.2f%s%6.2f%s%14.5f%s%4s\n", (0 == demangleStatus) ?
+  finalDemangle : kName.c_str(), outputDelimiter, kCallCount, outputDelimiter,
+                          kTime,
+                          outputDelimiter,
+                          (kTime / kernelTimes) * 100.0,
+                          outputDelimiter,
+                          (kTime / totalExecuteTime) * 100.0,
+                          outputDelimiter,
+                          kTimeMean,
+                          outputDelimiter,
+                          kType
+                          );
+          } else {
+                  printf("KokkosP: %s%s%llu%s%f%s%f%s%f%s%f%s%s\n",
+                          (0 == demangleStatus) ? finalDemangle : kName.c_str(),
+                          outputDelimiter,
+                          kCallCount,
+                          outputDelimiter,
+                          kTime,
+                          outputDelimiter,
+                          (kTime / kernelTimes) * 100.0,
+                          outputDelimiter,
+                          (kTime / totalExecuteTime) * 100.0,
+                          outputDelimiter,
+                          kTimeMean,
+                          outputDelimiter,
+                          kType
+                          );
+          }
+  }
 
-	printf("\n");
-	printf("KokkosP: Total Execution Time:        %15.6f seconds.\n", totalExecuteTime);
-	printf("KokkosP: Time in Kokkos Kernels:      %15.6f seconds.\n", kernelTimes);
-	printf("KokkosP: Time spent outside Kokkos:   %15.6f seconds.\n", (totalExecuteTime - kernelTimes));
+  printf("\n");
+  printf("KokkosP: Total Execution Time:        %15.6f seconds.\n",
+  totalExecuteTime); printf("KokkosP: Time in Kokkos Kernels:      %15.6f
+  seconds.\n", kernelTimes); printf("KokkosP: Time spent outside Kokkos: %15.6f
+  seconds.\n", (totalExecuteTime - kernelTimes));
 
-	const double percentKokkos = (kernelTimes / totalExecuteTime) * 100.0;
-	printf("KokkosP: Runtime in Kokkos Kernels:   %15.6f \%\n", percentKokkos);
-	printf("KokkosP: Unique kernels:              %22llu \n", (uint64_t) count_map.size());
-	printf("KokkosP: Parallel For Calls:          %22llu \n", uniqID);
+  const double percentKokkos = (kernelTimes / totalExecuteTime) * 100.0;
+  printf("KokkosP: Runtime in Kokkos Kernels:   %15.6f \%\n", percentKokkos);
+  printf("KokkosP: Unique kernels:              %22llu \n", (uint64_t)
+  count_map.size()); printf("KokkosP: Parallel For Calls:          %22llu \n",
+  uniqID);
 
-	printf("\n");
-	printf("======================================================================\n");
-	printf("\n");
+  printf("\n");
+  printf("======================================================================\n");
+  printf("\n");
 
-	if(NULL != outputDelimiter) {
-		free(outputDelimiter);
-	}*/
-
-
+  if(NULL != outputDelimiter) {
+          free(outputDelimiter);
+  }*/
 }
 
-extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = uniqID++;
+extern "C" void kokkosp_begin_parallel_for(const char* name,
+                                           const uint32_t devID,
+                                           uint64_t* kID) {
+  *kID = uniqID++;
 
-	if( (NULL == name) || (strcmp("", name) == 0) ) {
-		fprintf(stderr, "Error: kernel is empty\n");
-		exit(-1);
-	}
+  if ((NULL == name) || (strcmp("", name) == 0)) {
+    fprintf(stderr, "Error: kernel is empty\n");
+    exit(-1);
+  }
 
-	increment_counter(name, PARALLEL_FOR);
+  increment_counter(name, PARALLEL_FOR);
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
-	currentEntry->addFromTimer();
+  currentEntry->addFromTimer();
 }
 
-extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = uniqID++;
+extern "C" void kokkosp_begin_parallel_scan(const char* name,
+                                            const uint32_t devID,
+                                            uint64_t* kID) {
+  *kID = uniqID++;
 
-	if( (NULL == name) || (strcmp("", name) == 0) ) {
-		fprintf(stderr, "Error: kernel is empty\n");
-		exit(-1);
-	}
+  if ((NULL == name) || (strcmp("", name) == 0)) {
+    fprintf(stderr, "Error: kernel is empty\n");
+    exit(-1);
+  }
 
-	increment_counter(name, PARALLEL_SCAN);
+  increment_counter(name, PARALLEL_SCAN);
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
-	currentEntry->addFromTimer();
+  currentEntry->addFromTimer();
 }
 
-extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = uniqID++;
+extern "C" void kokkosp_begin_parallel_reduce(const char* name,
+                                              const uint32_t devID,
+                                              uint64_t* kID) {
+  *kID = uniqID++;
 
-	if( (NULL == name) || (strcmp("", name) == 0) ) {
-		fprintf(stderr, "Error: kernel is empty\n");
-		exit(-1);
-	}
+  if ((NULL == name) || (strcmp("", name) == 0)) {
+    fprintf(stderr, "Error: kernel is empty\n");
+    exit(-1);
+  }
 
-	increment_counter(name, PARALLEL_REDUCE);
+  increment_counter(name, PARALLEL_REDUCE);
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
-	currentEntry->addFromTimer();
+  currentEntry->addFromTimer();
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {
-        increment_counter_region(regionName, REGION);
+  increment_counter_region(regionName, REGION);
 }
 
 extern "C" void kokkosp_pop_profile_region() {
-        current_region_level--;
-        
-        // current_region_level is out of bounds, inform the user they 
-        // called popRegion too many times.
-        if (current_region_level < 0) {
-           current_region_level = 0;
-           std::cerr << "WARNING:: Kokkos::Profiling::popRegion() called outside " <<
-                   " of an actve region. Previous regions: ";
+  current_region_level--;
 
-          /* This code block will walk back through the non-null regions 
-           * pointers and print the names.  This takes advantage of a slight
-           * issue with regions logic: we never actually delete the 
-           * KernelPerformanceInfo objects.  If that ever changes this needs
-           * to be updated. 
-           */
-           for (int i = 0; i < 5; i++) {
-              if (regions[i] != 0 ) {
-                 std::cerr << (i == 0 ? " " : ";") << regions[i]->getName();
-              } else {
-                 break;
-              }
-           }
-           std::cerr << "\n";
-        } else {
-           // don't call addFromTimer if we are outside an active region
-           regions[current_region_level]->addFromTimer();
-        }
+  // current_region_level is out of bounds, inform the user they
+  // called popRegion too many times.
+  if (current_region_level < 0) {
+    current_region_level = 0;
+    std::cerr << "WARNING:: Kokkos::Profiling::popRegion() called outside "
+              << " of an actve region. Previous regions: ";
+
+    /* This code block will walk back through the non-null regions
+     * pointers and print the names.  This takes advantage of a slight
+     * issue with regions logic: we never actually delete the
+     * KernelPerformanceInfo objects.  If that ever changes this needs
+     * to be updated.
+     */
+    for (int i = 0; i < 5; i++) {
+      if (regions[i] != 0) {
+        std::cerr << (i == 0 ? " " : ";") << regions[i]->getName();
+      } else {
+        break;
+      }
+    }
+    std::cerr << "\n";
+  } else {
+    // don't call addFromTimer if we are outside an active region
+    regions[current_region_level]->addFromTimer();
+  }
 }

--- a/profiling/simple-kernel-timer/kp_kernel_timer.cpp
+++ b/profiling/simple-kernel-timer/kp_kernel_timer.cpp
@@ -117,7 +117,7 @@ extern "C" void kokkosp_init_library(const int loadSeq,
 	// initialize regions to 0s so we know if there is an object there
 	memset(&regions[0], 0, 512 * sizeof(KernelPerformanceInfo*));
 
-	printf("KokkosP: Example Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
+	printf("KokkosP: Simple Kernel Timer Library Initialized (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
 
 	initTime = seconds();
 }

--- a/profiling/simple-kernel-timer/kp_reader.cpp
+++ b/profiling/simple-kernel-timer/kp_reader.cpp
@@ -23,182 +23,192 @@
 
 #include "kp_kernel_info.h"
 
-bool compareKernelPerformanceInfo(KernelPerformanceInfo* left, KernelPerformanceInfo* right) {
-	return left->getTime() > right->getTime();
+bool compareKernelPerformanceInfo(KernelPerformanceInfo* left,
+                                  KernelPerformanceInfo* right) {
+  return left->getTime() > right->getTime();
 };
 
 int find_index(std::vector<KernelPerformanceInfo*>& kernels,
-	const char* kernelName) {
+               const char* kernelName) {
+  for (int i = 0; i < kernels.size(); i++) {
+    KernelPerformanceInfo* nextKernel = kernels[i];
 
-	for(int i = 0; i < kernels.size(); i++) {
-		KernelPerformanceInfo* nextKernel = kernels[i];
+    if (strcmp(nextKernel->getName(), kernelName) == 0) {
+      return i;
+    }
+  }
 
-		if(strcmp(nextKernel->getName(), kernelName) == 0) {
-			return i;
-		}
-	}
-
-	return -1;
+  return -1;
 }
 
 int main(int argc, char* argv[]) {
+  if (argc == 1) {
+    fprintf(stderr, "Did you specify any data files on the command line!\n");
+    fprintf(stderr, "Usage: ./reader file1.dat [fileX.dat]*\n");
+    exit(-1);
+  }
 
-	if(argc == 1) {
-		fprintf(stderr, "Did you specify any data files on the command line!\n");
-		fprintf(stderr, "Usage: ./reader file1.dat [fileX.dat]*\n");
-		exit(-1);
-	}
+  char delimiter  = ' ';
+  int fixed_width = 0;
 
-        char delimiter   = ' ';
-        int fixed_width  = 0;
-
-        int commandline_args = 1;
-        while( (commandline_args<argc ) && (argv[commandline_args][0]=='-') ) {
-          if(strcmp(argv[commandline_args],"--delimiter")==0) {
-            delimiter=argv[++commandline_args][0];
-          }
-          if(strcmp(argv[commandline_args],"--fixed-width")==0) {
-            fixed_width=atoi(argv[++commandline_args]);
-          }
-
-          commandline_args++;
-        }
-
-	std::vector<KernelPerformanceInfo*> kernelInfo;
-	double totalKernelsTime = 0;
-	double totalExecuteTime = 0;
-	uint64_t totalKernelsCalls = 0;
-
-	for(int i = commandline_args; i < argc; i++) {
-		FILE* the_file = fopen(argv[i], "rb");
-
-		double fileExecuteTime = 0;
-		fread(&fileExecuteTime, sizeof(fileExecuteTime), 1, the_file);
-
-		totalExecuteTime += fileExecuteTime;
-
-		while(! feof(the_file)) {
-			KernelPerformanceInfo* new_kernel = new KernelPerformanceInfo("", PARALLEL_FOR);
-			if(new_kernel->readFromFile(the_file)) {
-			   if(strlen(new_kernel->getName()) > 0) {
-				int kernelIndex = find_index(kernelInfo, new_kernel->getName());
-
-				if(kernelIndex > -1) {
-					kernelInfo[kernelIndex]->addTime(new_kernel->getTime());
-					kernelInfo[kernelIndex]->addCallCount(new_kernel->getCallCount());
-				} else {
-					kernelInfo.push_back(new_kernel);
-				}
-                           }
-			}
-		}
-
-		fclose(the_file);
-	}
-
-	std::sort(kernelInfo.begin(), kernelInfo.end(), compareKernelPerformanceInfo);
-
-	for(int i = 0; i < kernelInfo.size(); i++) {
-    if(kernelInfo[i]->getKernelType() != REGION) {
-		  totalKernelsTime += kernelInfo[i]->getTime();
-		  totalKernelsCalls += kernelInfo[i]->getCallCount();
+  int commandline_args = 1;
+  while ((commandline_args < argc) && (argv[commandline_args][0] == '-')) {
+    if (strcmp(argv[commandline_args], "--delimiter") == 0) {
+      delimiter = argv[++commandline_args][0];
     }
-	}
+    if (strcmp(argv[commandline_args], "--fixed-width") == 0) {
+      fixed_width = atoi(argv[++commandline_args]);
+    }
+
+    commandline_args++;
+  }
+
+  std::vector<KernelPerformanceInfo*> kernelInfo;
+  double totalKernelsTime    = 0;
+  double totalExecuteTime    = 0;
+  uint64_t totalKernelsCalls = 0;
+
+  for (int i = commandline_args; i < argc; i++) {
+    FILE* the_file = fopen(argv[i], "rb");
+
+    double fileExecuteTime = 0;
+    fread(&fileExecuteTime, sizeof(fileExecuteTime), 1, the_file);
+
+    totalExecuteTime += fileExecuteTime;
+
+    while (!feof(the_file)) {
+      KernelPerformanceInfo* new_kernel =
+          new KernelPerformanceInfo("", PARALLEL_FOR);
+      if (new_kernel->readFromFile(the_file)) {
+        if (strlen(new_kernel->getName()) > 0) {
+          int kernelIndex = find_index(kernelInfo, new_kernel->getName());
+
+          if (kernelIndex > -1) {
+            kernelInfo[kernelIndex]->addTime(new_kernel->getTime());
+            kernelInfo[kernelIndex]->addCallCount(new_kernel->getCallCount());
+          } else {
+            kernelInfo.push_back(new_kernel);
+          }
+        }
+      }
+    }
+
+    fclose(the_file);
+  }
+
+  std::sort(kernelInfo.begin(), kernelInfo.end(), compareKernelPerformanceInfo);
+
+  for (int i = 0; i < kernelInfo.size(); i++) {
+    if (kernelInfo[i]->getKernelType() != REGION) {
+      totalKernelsTime += kernelInfo[i]->getTime();
+      totalKernelsCalls += kernelInfo[i]->getCallCount();
+    }
+  }
 
   printf("Regions: \n\n");
 
-  for(int i = 0; i < kernelInfo.size(); i++) {
-		const double callCountDouble = (double) kernelInfo[i]->getCallCount();
+  for (int i = 0; i < kernelInfo.size(); i++) {
+    const double callCountDouble = (double)kernelInfo[i]->getCallCount();
 
-		if(kernelInfo[i]->getKernelType() != REGION) continue;
-    if(fixed_width)
-		printf("- %100s\n%11s%c%15.5f%c%12" PRIu64 "%c%15.5f%c%7.3f%c%7.3f\n",
-		  kernelInfo[i]->getName(),
-		   ( kernelInfo[i]->getKernelType() == PARALLEL_FOR) ? (
-		     " (ParFor)  " ) : (
-		   ( kernelInfo[i]->getKernelType() == PARALLEL_REDUCE) ? (
-	       " (ParRed)  " ) : (
-       ( kernelInfo[i]->getKernelType() == PARALLEL_SCAN) ? (
-         " (ParScan) " ) : (
-         " (Region)  " )
-	     )),
-			delimiter,kernelInfo[i]->getTime(),
-			delimiter,kernelInfo[i]->getCallCount(),
-			delimiter,kernelInfo[i]->getTime() / callCountDouble,
-			delimiter,(kernelInfo[i]->getTime() / totalKernelsTime) * 100.0,
-			delimiter,(kernelInfo[i]->getTime() / totalExecuteTime) * 100.0 );
+    if (kernelInfo[i]->getKernelType() != REGION) continue;
+    if (fixed_width)
+      printf("- %100s\n%11s%c%15.5f%c%12" PRIu64 "%c%15.5f%c%7.3f%c%7.3f\n",
+             kernelInfo[i]->getName(),
+             (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
+                 ? (" (ParFor)  ")
+                 : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
+                        ? (" (ParRed)  ")
+                        : ((kernelInfo[i]->getKernelType() == PARALLEL_SCAN)
+                               ? (" (ParScan) ")
+                               : (" (Region)  "))),
+             delimiter, kernelInfo[i]->getTime(), delimiter,
+             kernelInfo[i]->getCallCount(), delimiter,
+             kernelInfo[i]->getTime() / callCountDouble, delimiter,
+             (kernelInfo[i]->getTime() / totalKernelsTime) * 100.0, delimiter,
+             (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
     else
-    printf("- %s\n%s%c%f%c%" PRIu64 "%c%f%c%f%c%f\n", kernelInfo[i]->getName(),
-         ( kernelInfo[i]->getKernelType() == PARALLEL_FOR) ? (
-           " (ParFor)  " ) : (
-         ( kernelInfo[i]->getKernelType() == PARALLEL_REDUCE) ? (
-           " (ParRed)  " ) : (
-         ( kernelInfo[i]->getKernelType() == PARALLEL_SCAN) ? (
-           " (ParScan) " ) : (
-           " (REGION)  " )
-         )),
-      delimiter,kernelInfo[i]->getTime(),
-      delimiter,kernelInfo[i]->getCallCount(),
-      delimiter,kernelInfo[i]->getTime() / callCountDouble,
-      delimiter,(kernelInfo[i]->getTime() / totalKernelsTime) * 100.0,
-      delimiter,(kernelInfo[i]->getTime() / totalExecuteTime) * 100.0 );
-	}
-
-  printf("\n");
-  printf("-------------------------------------------------------------------------\n");
-  printf("Kernels: \n\n");
-
-  for(int i = 0; i < kernelInfo.size(); i++) {
-    const double callCountDouble = (double) kernelInfo[i]->getCallCount();
-
-    if(kernelInfo[i]->getKernelType() == REGION) continue;
-    if(fixed_width)
-    printf("- %100s\n%11s%c%15.5f%c%12" PRIu64 "%c%15.5f%c%7.3f%c%7.3f\n",
-      kernelInfo[i]->getName(),
-       ( kernelInfo[i]->getKernelType() == PARALLEL_FOR) ? (
-         " (ParFor)  " ) : (
-       ( kernelInfo[i]->getKernelType() == PARALLEL_REDUCE) ? (
-         " (ParRed)  " ) : (
-       ( kernelInfo[i]->getKernelType() == PARALLEL_SCAN) ? (
-         " (ParScan) " ) : (
-         " (Region)  " )
-       )),
-      delimiter,kernelInfo[i]->getTime(),
-      delimiter,kernelInfo[i]->getCallCount(),
-      delimiter,kernelInfo[i]->getTime() / callCountDouble,
-      delimiter,(kernelInfo[i]->getTime() / totalKernelsTime) * 100.0,
-      delimiter,(kernelInfo[i]->getTime() / totalExecuteTime) * 100.0 );
-    else
-    printf("- %s\n%s%c%f%c%" PRIu64 "%c%f%c%f%c%f\n", kernelInfo[i]->getName(),
-         ( kernelInfo[i]->getKernelType() == PARALLEL_FOR) ? (
-           " (ParFor)  " ) : (
-         ( kernelInfo[i]->getKernelType() == PARALLEL_REDUCE) ? (
-           " (ParRed)  " ) : (
-         ( kernelInfo[i]->getKernelType() == PARALLEL_SCAN) ? (
-           " (ParScan) " ) : (
-           " (REGION)  " )
-         )),
-      delimiter,kernelInfo[i]->getTime(),
-      delimiter,kernelInfo[i]->getCallCount(),
-      delimiter,kernelInfo[i]->getTime() / callCountDouble,
-      delimiter,(kernelInfo[i]->getTime() / totalKernelsTime) * 100.0,
-      delimiter,(kernelInfo[i]->getTime() / totalExecuteTime) * 100.0 );
+      printf("- %s\n%s%c%f%c%" PRIu64 "%c%f%c%f%c%f\n",
+             kernelInfo[i]->getName(),
+             (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
+                 ? (" (ParFor)  ")
+                 : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
+                        ? (" (ParRed)  ")
+                        : ((kernelInfo[i]->getKernelType() == PARALLEL_SCAN)
+                               ? (" (ParScan) ")
+                               : (" (REGION)  "))),
+             delimiter, kernelInfo[i]->getTime(), delimiter,
+             kernelInfo[i]->getCallCount(), delimiter,
+             kernelInfo[i]->getTime() / callCountDouble, delimiter,
+             (kernelInfo[i]->getTime() / totalKernelsTime) * 100.0, delimiter,
+             (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
   }
 
-	printf("\n");
-	printf("-------------------------------------------------------------------------\n");
-	printf("Summary:\n");
-	printf("\n");
-	printf("Total Execution Time (incl. Kokkos + non-Kokkos):      %20.5f seconds\n", totalExecuteTime);
-	printf("Total Time in Kokkos kernels:                          %20.5f seconds\n", totalKernelsTime);
-	printf("   -> Time outside Kokkos kernels:                     %20.5f seconds\n",
-		(totalExecuteTime - totalKernelsTime));
-	printf("   -> Percentage in Kokkos kernels:                    %20.2f %%\n",
-		(totalKernelsTime / totalExecuteTime) * 100);
-	printf("Total Calls to Kokkos Kernels:                         %20" PRIu64 "\n", totalKernelsCalls);
-	printf("\n");
-	printf("-------------------------------------------------------------------------\n");
+  printf("\n");
+  printf(
+      "------------------------------------------------------------------------"
+      "-\n");
+  printf("Kernels: \n\n");
 
-	return 0;
+  for (int i = 0; i < kernelInfo.size(); i++) {
+    const double callCountDouble = (double)kernelInfo[i]->getCallCount();
 
+    if (kernelInfo[i]->getKernelType() == REGION) continue;
+    if (fixed_width)
+      printf("- %100s\n%11s%c%15.5f%c%12" PRIu64 "%c%15.5f%c%7.3f%c%7.3f\n",
+             kernelInfo[i]->getName(),
+             (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
+                 ? (" (ParFor)  ")
+                 : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
+                        ? (" (ParRed)  ")
+                        : ((kernelInfo[i]->getKernelType() == PARALLEL_SCAN)
+                               ? (" (ParScan) ")
+                               : (" (Region)  "))),
+             delimiter, kernelInfo[i]->getTime(), delimiter,
+             kernelInfo[i]->getCallCount(), delimiter,
+             kernelInfo[i]->getTime() / callCountDouble, delimiter,
+             (kernelInfo[i]->getTime() / totalKernelsTime) * 100.0, delimiter,
+             (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
+    else
+      printf("- %s\n%s%c%f%c%" PRIu64 "%c%f%c%f%c%f\n",
+             kernelInfo[i]->getName(),
+             (kernelInfo[i]->getKernelType() == PARALLEL_FOR)
+                 ? (" (ParFor)  ")
+                 : ((kernelInfo[i]->getKernelType() == PARALLEL_REDUCE)
+                        ? (" (ParRed)  ")
+                        : ((kernelInfo[i]->getKernelType() == PARALLEL_SCAN)
+                               ? (" (ParScan) ")
+                               : (" (REGION)  "))),
+             delimiter, kernelInfo[i]->getTime(), delimiter,
+             kernelInfo[i]->getCallCount(), delimiter,
+             kernelInfo[i]->getTime() / callCountDouble, delimiter,
+             (kernelInfo[i]->getTime() / totalKernelsTime) * 100.0, delimiter,
+             (kernelInfo[i]->getTime() / totalExecuteTime) * 100.0);
+  }
+
+  printf("\n");
+  printf(
+      "------------------------------------------------------------------------"
+      "-\n");
+  printf("Summary:\n");
+  printf("\n");
+  printf(
+      "Total Execution Time (incl. Kokkos + non-Kokkos):      %20.5f seconds\n",
+      totalExecuteTime);
+  printf(
+      "Total Time in Kokkos kernels:                          %20.5f seconds\n",
+      totalKernelsTime);
+  printf(
+      "   -> Time outside Kokkos kernels:                     %20.5f seconds\n",
+      (totalExecuteTime - totalKernelsTime));
+  printf("   -> Percentage in Kokkos kernels:                    %20.2f %%\n",
+         (totalKernelsTime / totalExecuteTime) * 100);
+  printf("Total Calls to Kokkos Kernels:                         %20" PRIu64
+         "\n",
+         totalKernelsCalls);
+  printf("\n");
+  printf(
+      "------------------------------------------------------------------------"
+      "-\n");
+
+  return 0;
 }

--- a/profiling/simple-kernel-timer/kp_reader.cpp
+++ b/profiling/simple-kernel-timer/kp_reader.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #include <stdio.h>

--- a/profiling/space-time-stack/kp_space_time_stack.cpp
+++ b/profiling/space-time-stack/kp_space_time_stack.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 #include <cstdint>
 #include <cinttypes>

--- a/profiling/space-time-stack/kp_space_time_stack.cpp
+++ b/profiling/space-time-stack/kp_space_time_stack.cpp
@@ -51,31 +51,20 @@ struct SpaceHandle {
   char name[64];
 };
 
-enum Space {
-  SPACE_HOST,
-  SPACE_CUDA,
-  SPACE_HIP,
-  SPACE_SYCL,
-  SPACE_OMPT
-};
+enum Space { SPACE_HOST, SPACE_CUDA, SPACE_HIP, SPACE_SYCL, SPACE_OMPT };
 
 enum { NSPACES = 5 };
 
 Space get_space(SpaceHandle const& handle) {
   // check that name starts with "Cuda"
-  if (strncmp(handle.name, "Cuda", 4) == 0)
-    return SPACE_CUDA;
+  if (strncmp(handle.name, "Cuda", 4) == 0) return SPACE_CUDA;
   // check that name starts with "SYCL"
-  if (strncmp(handle.name, "SYCL", 4) == 0)
-    return SPACE_SYCL;
+  if (strncmp(handle.name, "SYCL", 4) == 0) return SPACE_SYCL;
   // check that name starts with "OpenMPTarget"
-  if (strncmp(handle.name, "OpenMPTarget", 12) == 0)
-    return SPACE_OMPT;
+  if (strncmp(handle.name, "OpenMPTarget", 12) == 0) return SPACE_OMPT;
   // check that name starts with "HIP"
-  if (strncmp(handle.name, "HIP", 3) == 0)
-    return SPACE_HIP;
-  if (strcmp(handle.name, "Host") == 0)
-    return SPACE_HOST;
+  if (strncmp(handle.name, "HIP", 3) == 0) return SPACE_HIP;
+  if (strcmp(handle.name, "Host") == 0) return SPACE_HOST;
 
   abort();
   return SPACE_HOST;
@@ -121,7 +110,7 @@ enum StackKind {
 void print_process_hwm() {
   struct rusage sys_resources;
   getrusage(RUSAGE_SELF, &sys_resources);
-  long hwm = sys_resources.ru_maxrss;
+  long hwm     = sys_resources.ru_maxrss;
   long hwm_max = hwm;
 
 #if USE_MPI
@@ -146,10 +135,9 @@ void print_process_hwm() {
 #endif
   {
     printf("Host process high water mark memory consumption: %ld kB\n",
-      hwm_max);
+           hwm_max);
 #if USE_MPI
-    printf("  Max: %ld, Min: %ld, Ave: %ld kB\n",
-      hwm_max,hwm_min,hwm_ave);
+    printf("  Max: %ld, Min: %ld, Ave: %ld kB\n", hwm_max, hwm_min, hwm_ave);
 #endif
     printf("\n");
   }
@@ -165,23 +153,24 @@ struct StackNode {
   double max_runtime;
   double avg_runtime;
   std::int64_t number_of_calls;
-  std::int64_t total_number_of_kernel_calls;// Counts all kernel calls (but not region calls) this node and below this node in the tree
+  std::int64_t total_number_of_kernel_calls;  // Counts all kernel calls (but
+                                              // not region calls) this node and
+                                              // below this node in the tree
   Now start_time;
-  StackNode(StackNode* parent_in, std::string&& name_in, StackKind kind_in):
-    parent(parent_in),
-    name(std::move(name_in)),
-    kind(kind_in),
-    total_runtime(0.),
-    total_kokkos_runtime(0.),
-    number_of_calls(0),
-    total_number_of_kernel_calls(0) {
-  }
+  StackNode(StackNode* parent_in, std::string&& name_in, StackKind kind_in)
+      : parent(parent_in),
+        name(std::move(name_in)),
+        kind(kind_in),
+        total_runtime(0.),
+        total_kokkos_runtime(0.),
+        number_of_calls(0),
+        total_number_of_kernel_calls(0) {}
   StackNode* get_child(std::string&& child_name, StackKind child_kind) {
     StackNode candidate(this, std::move(child_name), child_kind);
     auto it = children.find(candidate);
     if (it == children.end()) {
       auto res = children.emplace(std::move(candidate));
-      it = res.first;
+      it       = res.first;
       assert(res.second);
     }
     return const_cast<StackNode*>(&(*(it)));
@@ -204,7 +193,8 @@ struct StackNode {
     number_of_calls++;
 
     // Regions are not kernels, so we don't tally those
-    if(kind==STACK_FOR || kind==STACK_REDUCE || kind==STACK_SCAN || kind==STACK_COPY)
+    if (kind == STACK_FOR || kind == STACK_REDUCE || kind == STACK_SCAN ||
+        kind == STACK_COPY)
       total_number_of_kernel_calls++;
     start_time = now();
   }
@@ -219,7 +209,7 @@ struct StackNode {
     for (auto& child : this->children) {
       const_cast<StackNode&>(child).adopt();
       this->total_kokkos_runtime += child.total_kokkos_runtime;
-      this->total_number_of_kernel_calls +=  child.total_number_of_kernel_calls;
+      this->total_number_of_kernel_calls += child.total_number_of_kernel_calls;
     }
     assert(this->total_kokkos_runtime >= 0.);
   }
@@ -228,24 +218,29 @@ struct StackNode {
     std::queue<StackNode const*> q;
     q.push(this);
     while (!q.empty()) {
-      auto node = q.front(); q.pop();
-      auto self_time = node->total_runtime;
+      auto node = q.front();
+      q.pop();
+      auto self_time        = node->total_runtime;
       auto self_kokkos_time = node->total_kokkos_runtime;
-      auto calls = node->number_of_calls;
+      auto calls            = node->number_of_calls;
       for (auto& child : node->children) {
         self_time -= child.total_runtime;
         self_kokkos_time -= child.total_kokkos_runtime;
         q.push(&child);
       }
-      self_time = std::max(self_time, 0.); // floating-point may give negative epsilon instead of zero
-      self_kokkos_time = std::max(self_kokkos_time, 0.); // floating-point may give negative epsilon instead of zero
+      self_time = std::max(
+          self_time,
+          0.);  // floating-point may give negative epsilon instead of zero
+      self_kokkos_time = std::max(
+          self_kokkos_time,
+          0.);  // floating-point may give negative epsilon instead of zero
       auto inv_node = &inv_root;
       inv_node->total_runtime += self_time;
       inv_node->number_of_calls += calls;
       inv_node->total_kokkos_runtime += self_kokkos_time;
       for (; node; node = node->parent) {
         std::string name = node->name;
-        inv_node = inv_node->get_child(std::move(name), node->kind);
+        inv_node         = inv_node->get_child(std::move(name), node->kind);
         inv_node->total_runtime += self_time;
         inv_node->number_of_calls += calls;
         inv_node->total_kokkos_runtime += self_kokkos_time;
@@ -253,10 +248,10 @@ struct StackNode {
     }
     return inv_root;
   }
-  void print_recursive_json(
-      std::ostream& os, StackNode const* parent, double tree_time) const {
+  void print_recursive_json(std::ostream& os, StackNode const* parent,
+                            double tree_time) const {
     static bool add_comma = false;
-    auto percent = (total_runtime / tree_time) * 100.0;
+    auto percent          = (total_runtime / tree_time) * 100.0;
     if (percent < 0.1) return;
     if (!name.empty()) {
       if (add_comma) os << ",\n";
@@ -274,24 +269,23 @@ struct StackNode {
       os << "\"imbalance\" : " << imbalance << ",\n";
 
       // Sum over kids if we're a region
-      if (kind==STACK_REGION) {
+      if (kind == STACK_REGION) {
         double child_runtime = 0.0;
         for (auto& child : children) {
           child_runtime += child.total_runtime;
         }
         auto remainder = (1.0 - child_runtime / total_runtime) * 100.0;
-        double kps = total_number_of_kernel_calls / avg_runtime;
+        double kps     = total_number_of_kernel_calls / avg_runtime;
         os << "\"remainder\" : " << remainder << ",\n";
-        os <<  std::scientific << std::setprecision(2);
+        os << std::scientific << std::setprecision(2);
         os << "\"kernels-per-second\" : " << kps << ",\n";
-      }
-      else
-      {
+      } else {
         os << "\"remainder\" : \"N/A\",\n";
         os << "\"kernels-per-second\" : \"N/A\",\n";
       }
       os << "\"number-of-calls\" : " << number_of_calls << ",\n";
-      auto name_escape_double_quote_twices = std::regex_replace(name, std::regex("\""), "\\\"");
+      auto name_escape_double_quote_twices =
+          std::regex_replace(name, std::regex("\""), "\\\"");
       os << "\"name\" : \"" << name_escape_double_quote_twices << "\",\n";
       os << "\"parent-id\" : \"" << parent << "\",\n";
       os << "\"id\" : \"" << this << "\",\n";
@@ -320,10 +314,10 @@ struct StackNode {
     }
     auto last = children_by_time.end();
     --last;
-    for (auto it = children_by_time.begin(); it != children_by_time.end(); ++it) {
+    for (auto it = children_by_time.begin(); it != children_by_time.end();
+         ++it) {
       auto child = *it;
-      child->print_recursive_json(
-          os, this, tree_time);
+      child->print_recursive_json(os, this, tree_time);
     }
   }
   void print_json(std::ostream& os) const {
@@ -336,8 +330,9 @@ struct StackNode {
     os << "]\n}\n";
     os.copyfmt(saved_state);
   }
-  void print_recursive(
-      std::ostream& os, std::string my_indent, std::string const& child_indent, double tree_time) const {
+  void print_recursive(std::ostream& os, std::string my_indent,
+                       std::string const& child_indent,
+                       double tree_time) const {
     auto percent = (total_runtime / tree_time) * 100.0;
     if (percent < 0.1) return;
     if (!name.empty()) {
@@ -349,17 +344,19 @@ struct StackNode {
       auto percent_kokkos = (total_kokkos_runtime / total_runtime) * 100.0;
 
       // Sum over kids if we're a region
-      if (kind==STACK_REGION) {
+      if (kind == STACK_REGION) {
         double child_runtime = 0.0;
         for (auto& child : children) {
           child_runtime += child.total_runtime;
         }
         auto remainder = (1.0 - child_runtime / total_runtime) * 100.0;
-        double kps = total_number_of_kernel_calls / avg_runtime;
-        os << percent << "% " << percent_kokkos << "% " << imbalance << "% " << remainder << "% " << std::scientific << std::setprecision(2) << kps << " " << number_of_calls << " " << name;
-      }
-      else
-        os << percent << "% " << percent_kokkos << "% " << imbalance << "% " << "------ " << number_of_calls << " " << name;
+        double kps     = total_number_of_kernel_calls / avg_runtime;
+        os << percent << "% " << percent_kokkos << "% " << imbalance << "% "
+           << remainder << "% " << std::scientific << std::setprecision(2)
+           << kps << " " << number_of_calls << " " << name;
+      } else
+        os << percent << "% " << percent_kokkos << "% " << imbalance << "% "
+           << "------ " << number_of_calls << " " << name;
 
       switch (kind) {
         case STACK_FOR: os << " [for]"; break;
@@ -368,7 +365,6 @@ struct StackNode {
         case STACK_REGION: os << " [region]"; break;
         case STACK_COPY: os << " [copy]"; break;
       };
-
 
       os << '\n';
     }
@@ -385,7 +381,8 @@ struct StackNode {
     }
     auto last = children_by_time.end();
     --last;
-    for (auto it = children_by_time.begin(); it != children_by_time.end(); ++it) {
+    for (auto it = children_by_time.begin(); it != children_by_time.end();
+         ++it) {
       std::string grandchild_indent;
       if (it == last) {
         grandchild_indent = child_indent + "    ";
@@ -393,8 +390,8 @@ struct StackNode {
         grandchild_indent = child_indent + "|   ";
       }
       auto child = *it;
-      child->print_recursive(
-          os, child_indent + "|-> ", grandchild_indent, tree_time);
+      child->print_recursive(os, child_indent + "|-> ", grandchild_indent,
+                             tree_time);
     }
   }
   void print(std::ostream& os) const {
@@ -413,26 +410,27 @@ struct StackNode {
     std::set<std::pair<std::string, StackKind>> children_to_process;
     q.push(this);
     while (!q.empty()) {
-      auto node = q.front(); q.pop();
+      auto node = q.front();
+      q.pop();
       node->max_runtime = node->total_runtime;
       node->avg_runtime = node->total_runtime;
-      MPI_Allreduce(MPI_IN_PLACE, &(node->total_runtime),
-          1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-      MPI_Allreduce(MPI_IN_PLACE, &(node->max_runtime),
-          1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
-      MPI_Allreduce(MPI_IN_PLACE, &(node->avg_runtime),
-          1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+      MPI_Allreduce(MPI_IN_PLACE, &(node->total_runtime), 1, MPI_DOUBLE,
+                    MPI_SUM, MPI_COMM_WORLD);
+      MPI_Allreduce(MPI_IN_PLACE, &(node->max_runtime), 1, MPI_DOUBLE, MPI_MAX,
+                    MPI_COMM_WORLD);
+      MPI_Allreduce(MPI_IN_PLACE, &(node->avg_runtime), 1, MPI_DOUBLE, MPI_SUM,
+                    MPI_COMM_WORLD);
       node->avg_runtime /= comm_size;
-      MPI_Allreduce(MPI_IN_PLACE, &(node->total_kokkos_runtime),
-          1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-      /* Not all children necessarily exist on every rank. To handle this we will:
-         1) Build a set of the child node names on each rank.
-         2) Start with rank 0, broadcast all of it's child names and add them to the
+      MPI_Allreduce(MPI_IN_PLACE, &(node->total_kokkos_runtime), 1, MPI_DOUBLE,
+                    MPI_SUM, MPI_COMM_WORLD);
+      /* Not all children necessarily exist on every rank. To handle this we
+         will: 1) Build a set of the child node names on each rank. 2) Start
+         with rank 0, broadcast all of it's child names and add them to the
             queue, removing them from the set of names to be processed.
             If a child doesn't exist on a rank we add an empty node for it.
-         3) Do a check for the lowest rank that has any remaining unprocessed children
-            and repeat step 2 broadcasting from that rank until we process all children
-            from all ranks.
+         3) Do a check for the lowest rank that has any remaining unprocessed
+         children and repeat step 2 broadcasting from that rank until we process
+         all children from all ranks.
        */
       children_to_process.clear();
       for (auto& child : node->children) {
@@ -440,19 +438,21 @@ struct StackNode {
       }
 
       int bcast_rank = 0;
-      do
-      {
+      do {
         int nchildren_to_process = int(children_to_process.size());
-        MPI_Bcast(&nchildren_to_process, 1, MPI_INT, bcast_rank, MPI_COMM_WORLD);
+        MPI_Bcast(&nchildren_to_process, 1, MPI_INT, bcast_rank,
+                  MPI_COMM_WORLD);
         if (rank == bcast_rank) {
           for (auto& child_info : children_to_process) {
             std::string child_name = child_info.first;
-            int kind = child_info.second;
-            int name_len = child_name.length();
+            int kind               = child_info.second;
+            int name_len           = child_name.length();
             MPI_Bcast(&name_len, 1, MPI_INT, bcast_rank, MPI_COMM_WORLD);
-            MPI_Bcast(&child_name[0], name_len, MPI_CHAR, bcast_rank, MPI_COMM_WORLD);
+            MPI_Bcast(&child_name[0], name_len, MPI_CHAR, bcast_rank,
+                      MPI_COMM_WORLD);
             MPI_Bcast(&kind, 1, MPI_INT, bcast_rank, MPI_COMM_WORLD);
-            auto * child = node->get_child(std::move(child_name), StackKind(kind));
+            auto* child =
+                node->get_child(std::move(child_name), StackKind(kind));
             q.push(child);
           }
           children_to_process.clear();
@@ -469,15 +469,18 @@ struct StackNode {
             children_to_process.erase({child->name, child->kind});
           }
         }
-        int local_next_bcast_rank = children_to_process.empty() ? comm_size : rank;
-        MPI_Allreduce(&local_next_bcast_rank, &bcast_rank, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
-      } while(bcast_rank < comm_size);
+        int local_next_bcast_rank =
+            children_to_process.empty() ? comm_size : rank;
+        MPI_Allreduce(&local_next_bcast_rank, &bcast_rank, 1, MPI_INT, MPI_MIN,
+                      MPI_COMM_WORLD);
+      } while (bcast_rank < comm_size);
     }
 #else
     std::queue<StackNode*> q;
     q.push(this);
     while (!q.empty()) {
-      auto node = q.front(); q.pop();
+      auto node = q.front();
+      q.pop();
       node->max_runtime = node->total_runtime;
       node->avg_runtime = node->total_runtime;
       for (auto& child : node->children) {
@@ -494,9 +497,8 @@ struct Allocation {
   std::uint64_t size;
   StackNode* frame;
   Allocation(std::string&& name_in, void* ptr_in, std::uint64_t size_in,
-      StackNode* frame_in):
-    name(std::move(name_in)),ptr(ptr_in),size(size_in),frame(frame_in) {
-  }
+             StackNode* frame_in)
+      : name(std::move(name_in)), ptr(ptr_in), size(size_in), frame(frame_in) {}
   bool operator<(Allocation const& other) const {
     if (size != other.size) return size > other.size;
     return ptr < other.ptr;
@@ -506,22 +508,22 @@ struct Allocation {
 struct Allocations {
   std::uint64_t total_size;
   std::set<Allocation> alloc_set;
-  Allocations():total_size(0) {}
+  Allocations() : total_size(0) {}
   void allocate(std::string&& name, void* ptr, std::uint64_t size,
-      StackNode* frame) {
-    auto res = alloc_set.emplace(
-        Allocation(std::move(name), ptr, size, frame));
+                StackNode* frame) {
+    auto res = alloc_set.emplace(Allocation(std::move(name), ptr, size, frame));
     assert(res.second);
     total_size += size;
   }
   void deallocate(std::string&& name, void* ptr, std::uint64_t size,
-      StackNode* frame) {
+                  StackNode* frame) {
     auto key = Allocation(std::move(name), ptr, size, frame);
-    auto it = alloc_set.find(key);
+    auto it  = alloc_set.find(key);
     if (it == alloc_set.end()) {
       std::stringstream ss;
-      ss << "WARNING! allocation(\"" << key.name << "\", " << key.ptr
-         << ", " << key.size << "), deallocated at \"" << frame->get_full_name() << "\", "
+      ss << "WARNING! allocation(\"" << key.name << "\", " << key.ptr << ", "
+         << key.size << "), deallocated at \"" << frame->get_full_name()
+         << "\", "
          << " was not in the currently allocated set!\n";
       auto s = ss.str();
       std::cerr << s;
@@ -534,8 +536,8 @@ struct Allocations {
     std::string s;
 #if USE_MPI
     auto max_total_size = total_size;
-    MPI_Allreduce(MPI_IN_PLACE, &max_total_size, 1,
-        MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &max_total_size, 1, MPI_UINT64_T, MPI_MAX,
+                  MPI_COMM_WORLD);
     /* this bit of logic is here to break ties in case two
      * or more MPI ranks allocated the same (maximum) amount of
      * memory. the one with the lowest MPI rank will print
@@ -544,15 +546,16 @@ struct Allocations {
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     auto min_max_rank = (max_total_size == total_size) ? rank : size;
-    MPI_Allreduce(MPI_IN_PLACE, &min_max_rank, 1,
-        MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &min_max_rank, 1, MPI_INT, MPI_MIN,
+                  MPI_COMM_WORLD);
     assert(min_max_rank < size);
     if (rank == min_max_rank)
 #endif
     {
       std::stringstream ss;
       ss << std::fixed << std::setprecision(1);
-      ss << "MAX MEMORY ALLOCATED: " << double(total_size)/1024.0 << " kB" << '\n'; // convert bytes to kB
+      ss << "MAX MEMORY ALLOCATED: " << double(total_size) / 1024.0 << " kB"
+         << '\n';  // convert bytes to kB
 #if USE_MPI
       ss << "MPI RANK WITH MAX MEMORY: " << rank << '\n';
 #endif
@@ -562,8 +565,10 @@ struct Allocations {
         auto percent = double(allocation.size) / double(total_size) * 100.0;
         if (percent < 0.1) continue;
         std::string full_name = allocation.frame->get_full_name();
-        if (full_name.empty()) full_name = allocation.name;
-        else full_name = full_name + "/" + allocation.name;
+        if (full_name.empty())
+          full_name = allocation.name;
+        else
+          full_name = full_name + "/" + allocation.name;
         ss << "  " << percent << "% " << full_name << '\n';
       }
       ss << '\n';
@@ -574,7 +579,8 @@ struct Allocations {
     MPI_Request request;
     int string_size;
     if (rank == 0) {
-      MPI_Irecv(&string_size, 1, MPI_INT, min_max_rank, 42, MPI_COMM_WORLD, &request);
+      MPI_Irecv(&string_size, 1, MPI_INT, min_max_rank, 42, MPI_COMM_WORLD,
+                &request);
     }
     if (rank == min_max_rank) {
       string_size = int(s.size());
@@ -583,10 +589,12 @@ struct Allocations {
     if (rank == 0) {
       MPI_Wait(&request, MPI_STATUS_IGNORE);
       s.resize(size_t(string_size));
-      MPI_Irecv(const_cast<char*>(s.data()), string_size, MPI_CHAR, min_max_rank, 42, MPI_COMM_WORLD, &request);
+      MPI_Irecv(const_cast<char*>(s.data()), string_size, MPI_CHAR,
+                min_max_rank, 42, MPI_COMM_WORLD, &request);
     }
     if (rank == min_max_rank) {
-      MPI_Send(const_cast<char*>(s.data()), string_size, MPI_CHAR, 0, 42, MPI_COMM_WORLD);
+      MPI_Send(const_cast<char*>(s.data()), string_size, MPI_CHAR, 0, 42,
+               MPI_COMM_WORLD);
     }
     if (rank == 0) {
       MPI_Wait(&request, MPI_STATUS_IGNORE);
@@ -603,7 +611,7 @@ struct State {
   StackNode* stack_frame;
   Allocations current_allocations[NSPACES];
   Allocations hwm_allocations[NSPACES];
-  State():stack_root(nullptr, "", STACK_REGION),stack_frame(&stack_root) {
+  State() : stack_root(nullptr, "", STACK_REGION), stack_frame(&stack_root) {
     stack_frame->begin();
   }
   ~State() {
@@ -627,7 +635,7 @@ struct State {
 #if USE_MPI
       }
 #endif
-        return;
+      return;
     }
 
     auto inv_stack_root = stack_root.invert();
@@ -641,11 +649,15 @@ struct State {
       std::cout << "\nBEGIN KOKKOS PROFILING REPORT:\n";
       std::cout << "TOTAL TIME: " << stack_root.max_runtime << " seconds\n";
       std::cout << "TOP-DOWN TIME TREE:\n";
-      std::cout << "<average time> <percent of total time> <percent time in Kokkos> <percent MPI imbalance> <remainder> <kernels per second> <number of calls> <name> [type]\n";
+      std::cout << "<average time> <percent of total time> <percent time in "
+                   "Kokkos> <percent MPI imbalance> <remainder> <kernels per "
+                   "second> <number of calls> <name> [type]\n";
       std::cout << "=================== \n";
       stack_root.print(std::cout);
       std::cout << "BOTTOM-UP TIME TREE:\n";
-      std::cout << "<average time> <percent of total time> <percent time in Kokkos> <percent MPI imbalance> <number of calls> <name> [type]\n";
+      std::cout
+          << "<average time> <percent of total time> <percent time in Kokkos> "
+             "<percent MPI imbalance> <number of calls> <name> [type]\n";
       std::cout << "=================== \n";
       inv_stack_root.print(std::cout);
     }
@@ -683,7 +695,7 @@ struct State {
     return reinterpret_cast<std::uint64_t>(stack_frame);
   }
   void end_kernel(std::uint64_t kernid) {
-    auto end_time = now();
+    auto end_time    = now();
     auto expect_node = reinterpret_cast<StackNode*>(kernid);
     if (expect_node != stack_frame) {
       std::cerr << "Expected \"" << stack_frame->get_full_name()
@@ -692,27 +704,23 @@ struct State {
     }
     end_frame(end_time);
   }
-  void push_region(const char* name) {
-    begin_frame(name, STACK_REGION);
-  }
-  void pop_region() {
-    end_frame(now());
-  }
+  void push_region(const char* name) { begin_frame(name, STACK_REGION); }
+  void pop_region() { end_frame(now()); }
   void allocate(Space space, const char* name, void* ptr, std::uint64_t size) {
-    current_allocations[space].allocate(
-        std::string(name), ptr, size, stack_frame);
-    if (current_allocations[space].total_size > hwm_allocations[space].total_size) {
+    current_allocations[space].allocate(std::string(name), ptr, size,
+                                        stack_frame);
+    if (current_allocations[space].total_size >
+        hwm_allocations[space].total_size) {
       hwm_allocations[space] = current_allocations[space];
     }
   }
-  void deallocate(Space space, const char* name, void* ptr, std::uint64_t size) {
-    current_allocations[space].deallocate(
-        std::string(name), ptr, size, stack_frame);
+  void deallocate(Space space, const char* name, void* ptr,
+                  std::uint64_t size) {
+    current_allocations[space].deallocate(std::string(name), ptr, size,
+                                          stack_frame);
   }
-  void begin_deep_copy(
-      Space, const char* dst_name, const void*,
-      Space, const char* src_name, const void*,
-      std::uint64_t) {
+  void begin_deep_copy(Space, const char* dst_name, const void*, Space,
+                       const char* src_name, const void*, std::uint64_t) {
     std::string frame_name;
     frame_name += "\"";
     frame_name += dst_name;
@@ -721,17 +729,15 @@ struct State {
     frame_name += "\"";
     begin_frame(frame_name.c_str(), STACK_COPY);
   }
-  void end_deep_copy() {
-    end_frame(now());
-  }
+  void end_deep_copy() { end_frame(now()); }
 };
 
 State* global_state = nullptr;
 
 }  // end anonymous namespace
 
-extern "C" void kokkosp_init_library(
-    int loadseq, uint64_t, uint32_t ndevinfos, KokkosPDeviceInfo* devinfos) {
+extern "C" void kokkosp_init_library(int loadseq, uint64_t, uint32_t ndevinfos,
+                                     KokkosPDeviceInfo* devinfos) {
   (void)loadseq;
   (void)ndevinfos;
   (void)devinfos;
@@ -743,21 +749,24 @@ extern "C" void kokkosp_finalize_library() {
   global_state = nullptr;
 }
 
-extern "C" void kokkosp_begin_parallel_for(
-    const char* name, std::uint32_t devid, std::uint64_t* kernid) {
-  (void) devid;
+extern "C" void kokkosp_begin_parallel_for(const char* name,
+                                           std::uint32_t devid,
+                                           std::uint64_t* kernid) {
+  (void)devid;
   *kernid = global_state->begin_kernel(name, STACK_FOR);
 }
 
-extern "C" void kokkosp_begin_parallel_reduce(
-    const char* name, std::uint32_t devid, std::uint64_t* kernid) {
-  (void) devid;
+extern "C" void kokkosp_begin_parallel_reduce(const char* name,
+                                              std::uint32_t devid,
+                                              std::uint64_t* kernid) {
+  (void)devid;
   *kernid = global_state->begin_kernel(name, STACK_REDUCE);
 }
 
-extern "C" void kokkosp_begin_parallel_scan(
-    const char* name, std::uint32_t devid, std::uint64_t* kernid) {
-  (void) devid;
+extern "C" void kokkosp_begin_parallel_scan(const char* name,
+                                            std::uint32_t devid,
+                                            std::uint64_t* kernid) {
+  (void)devid;
   *kernid = global_state->begin_kernel(name, STACK_SCAN);
 }
 
@@ -777,32 +786,30 @@ extern "C" void kokkosp_push_profile_region(const char* name) {
   global_state->push_region(name);
 }
 
-extern "C" void kokkosp_pop_profile_region() {
-  global_state->pop_region();
-}
+extern "C" void kokkosp_pop_profile_region() { global_state->pop_region(); }
 
-extern "C" void kokkosp_allocate_data(
-    SpaceHandle handle, const char* name, void* ptr, uint64_t size) {
+extern "C" void kokkosp_allocate_data(SpaceHandle handle, const char* name,
+                                      void* ptr, uint64_t size) {
   auto space = get_space(handle);
   global_state->allocate(space, name, ptr, size);
 }
 
-extern "C" void kokkosp_deallocate_data(
-    SpaceHandle handle, const char* name, void* ptr, uint64_t size) {
+extern "C" void kokkosp_deallocate_data(SpaceHandle handle, const char* name,
+                                        void* ptr, uint64_t size) {
   auto space = get_space(handle);
   global_state->deallocate(space, name, ptr, size);
 }
 
-extern "C" void kokkosp_begin_deep_copy(
-    SpaceHandle dst_handle, const char* dst_name, const void* dst_ptr,
-    SpaceHandle src_handle, const char* src_name, const void* src_ptr,
-    uint64_t size) {
+extern "C" void kokkosp_begin_deep_copy(SpaceHandle dst_handle,
+                                        const char* dst_name,
+                                        const void* dst_ptr,
+                                        SpaceHandle src_handle,
+                                        const char* src_name,
+                                        const void* src_ptr, uint64_t size) {
   auto dst_space = get_space(dst_handle);
   auto src_space = get_space(src_handle);
-  global_state->begin_deep_copy(dst_space, dst_name, dst_ptr,
-      src_space, src_name, src_ptr, size);
+  global_state->begin_deep_copy(dst_space, dst_name, dst_ptr, src_space,
+                                src_name, src_ptr, size);
 }
 
-extern "C" void kokkosp_end_deep_copy() {
-  global_state->end_deep_copy();
-}
+extern "C" void kokkosp_end_deep_copy() { global_state->end_deep_copy(); }

--- a/profiling/systemtap-connector/kp_systemtap_connector.cpp
+++ b/profiling/systemtap-connector/kp_systemtap_connector.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 #include <stdio.h>
 #include <inttypes.h>

--- a/profiling/systemtap-connector/kp_systemtap_connector.cpp
+++ b/profiling/systemtap-connector/kp_systemtap_connector.cpp
@@ -27,152 +27,142 @@
 #include "probes.h"
 
 struct SpaceHandle {
-  char name[64];                                                                        
+  char name[64];
 };
 
 static uint64_t next_kernid;
 static uint32_t next_sec_id;
 
-extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devid, uint64_t* kernid)
-{
+extern "C" void kokkosp_begin_parallel_for(const char* name,
+                                           const uint32_t devid,
+                                           uint64_t* kernid) {
   *kernid = next_kernid++;
-  if ( KOKKOS_END_PARALLEL_FOR_ENABLED()) {
+  if (KOKKOS_END_PARALLEL_FOR_ENABLED()) {
     KOKKOS_BEGIN_PARALLEL_FOR(name, devid, kernid);
   }
 }
 
-extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t devid, uint64_t* kernid)
-{
+extern "C" void kokkosp_begin_parallel_scan(const char* name,
+                                            const uint32_t devid,
+                                            uint64_t* kernid) {
   *kernid = next_kernid++;
   if (KOKKOS_BEGIN_PARALLEL_SCAN_ENABLED()) {
     KOKKOS_BEGIN_PARALLEL_SCAN(name, devid, kernid);
   }
 }
 
-extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devid, uint64_t* kernid)
-{
+extern "C" void kokkosp_begin_parallel_reduce(const char* name,
+                                              const uint32_t devid,
+                                              uint64_t* kernid) {
   *kernid = next_kernid++;
   if (KOKKOS_BEGIN_PARALLEL_REDUCE_ENABLED()) {
     KOKKOS_BEGIN_PARALLEL_REDUCE(name, devid, kernid);
   }
 }
 
-extern "C" void kokkosp_end_parallel_scan(uint64_t kernid)
-{
+extern "C" void kokkosp_end_parallel_scan(uint64_t kernid) {
   if (KOKKOS_END_PARALLEL_SCAN_ENABLED()) {
     KOKKOS_END_PARALLEL_SCAN(kernid);
   }
 }
 
-extern "C" void kokkosp_end_parallel_for(uint64_t kernid)
-{
+extern "C" void kokkosp_end_parallel_for(uint64_t kernid) {
   if (KOKKOS_END_PARALLEL_FOR_ENABLED()) {
     KOKKOS_END_PARALLEL_FOR(kernid);
   }
 }
 
-extern "C" void kokkosp_end_parallel_reduce(uint64_t kernid)
-{
+extern "C" void kokkosp_end_parallel_reduce(uint64_t kernid) {
   if (KOKKOS_END_PARALLEL_REDUCE_ENABLED()) {
     KOKKOS_END_PARALLEL_REDUCE(kernid);
   }
 }
 
-extern "C" void kokkosp_init_library(const int loadseq,
-	const uint64_t version,
-	const uint32_t ndevinfos,
-	void* deviceinfos)
-{
+extern "C" void kokkosp_init_library(const int loadseq, const uint64_t version,
+                                     const uint32_t ndevinfos,
+                                     void* deviceinfos) {
   if (KOKKOS_INIT_LIBRARY_ENABLED()) {
     KOKKOS_INIT_LIBRARY(loadseq, version, ndevinfos, deviceinfos);
   }
 }
 
-extern "C" void kokkosp_finalize_library()
-{
+extern "C" void kokkosp_finalize_library() {
   if (KOKKOS_FINALIZE_LIBRARY_ENABLED()) {
     KOKKOS_FINALIZE_LIBRARY();
   }
 }
 
-extern "C" void kokkosp_push_profile_region(const char* name)
-{
+extern "C" void kokkosp_push_profile_region(const char* name) {
   if (KOKKOS_PUSH_PROFILE_REGION_ENABLED()) {
     KOKKOS_PUSH_PROFILE_REGION(name);
   }
 }
 
-extern "C" void kokkosp_pop_profile_region()
-{
+extern "C" void kokkosp_pop_profile_region() {
   if (KOKKOS_POP_PROFILE_REGION_ENABLED()) {
     KOKKOS_POP_PROFILE_REGION();
   }
 }
 
-extern "C" void kokkosp_allocate_data(SpaceHandle handle, const char* name, void* ptr, uint64_t size)
-{
+extern "C" void kokkosp_allocate_data(SpaceHandle handle, const char* name,
+                                      void* ptr, uint64_t size) {
   if (KOKKOS_ALLOCATE_DATA_ENABLED()) {
     KOKKOS_ALLOCATE_DATA(handle, name, ptr, size);
   }
 }
 
-extern "C" void kokkosp_deallocate_data(SpaceHandle handle, const char* name, void* ptr, uint64_t size)
-{
+extern "C" void kokkosp_deallocate_data(SpaceHandle handle, const char* name,
+                                        void* ptr, uint64_t size) {
   if (KOKKOS_DEALLOCATE_DATA_ENABLED()) {
     KOKKOS_DEALLOCATE_DATA(handle, name, ptr, size);
   }
 }
 
-extern "C" void kokkosp_begin_deep_copy(
-    SpaceHandle dst_handle, const char* dst_name, const void* dst_ptr,
-    SpaceHandle src_handle, const char* src_name, const void* src_ptr,
-    uint64_t size)
-{
+extern "C" void kokkosp_begin_deep_copy(SpaceHandle dst_handle,
+                                        const char* dst_name,
+                                        const void* dst_ptr,
+                                        SpaceHandle src_handle,
+                                        const char* src_name,
+                                        const void* src_ptr, uint64_t size) {
   if (KOKKOS_BEGIN_DEEP_COPY_ENABLED()) {
-    KOKKOS_BEGIN_DEEP_COPY(dst_handle, dst_name, dst_ptr,
-                      src_handle, src_name, src_ptr,
-                      size);
+    KOKKOS_BEGIN_DEEP_COPY(dst_handle, dst_name, dst_ptr, src_handle, src_name,
+                           src_ptr, size);
   }
 }
 
-extern "C" void kokkosp_end_deep_copy()
-{
+extern "C" void kokkosp_end_deep_copy() {
   if (KOKKOS_END_DEEP_COPY_ENABLED()) {
     KOKKOS_END_DEEP_COPY();
   }
 }
-      
-extern "C" void kokkosp_create_profile_section(const char* name, uint32_t* sec_id)
-{
+
+extern "C" void kokkosp_create_profile_section(const char* name,
+                                               uint32_t* sec_id) {
   *sec_id = next_sec_id++;
   if (KOKKOS_CREATE_PROFILE_SECTION_ENABLED()) {
     KOKKOS_CREATE_PROFILE_SECTION(name, sec_id);
   }
 }
 
-extern "C" void kokkosp_start_profile_section(const uint32_t sec_id)
-{
+extern "C" void kokkosp_start_profile_section(const uint32_t sec_id) {
   if (KOKKOS_START_PROFILE_SECTION_ENABLED()) {
     KOKKOS_START_PROFILE_SECTION(sec_id);
   }
 }
 
-extern "C" void kokkosp_stop_profile_section(const uint32_t sec_id)
-{
+extern "C" void kokkosp_stop_profile_section(const uint32_t sec_id) {
   if (KOKKOS_STOP_PROFILE_SECTION_ENABLED()) {
     KOKKOS_STOP_PROFILE_SECTION(sec_id);
   }
 }
 
-extern "C" void kokkosp_destroy_profile_section(const uint32_t sec_id)
-{
+extern "C" void kokkosp_destroy_profile_section(const uint32_t sec_id) {
   if (KOKKOS_DESTROY_PROFILE_SECTION_ENABLED()) {
     KOKKOS_DESTROY_PROFILE_SECTION(sec_id);
   }
 }
-      
-extern "C" void kokkosp_profile_event(const char* name)
-{
+
+extern "C" void kokkosp_profile_event(const char* name) {
   if (KOKKOS_PROFILE_EVENT_ENABLED()) {
     KOKKOS_PROFILE_EVENT(name);
   }

--- a/profiling/variorum-connector/variorum-connector.cpp
+++ b/profiling/variorum-connector/variorum-connector.cpp
@@ -1,47 +1,21 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-// 
-// ************************************************************************
 //@HEADER
 
 //Modified by Zach Frye at LLNL
-//Contact: frye7@llnl.gov 
+//Contact: frye7@llnl.gov
 //Organization: CASC at LLNL
 
 #include <stdio.h>

--- a/profiling/variorum-connector/variorum-connector.cpp
+++ b/profiling/variorum-connector/variorum-connector.cpp
@@ -14,9 +14,9 @@
 //
 //@HEADER
 
-//Modified by Zach Frye at LLNL
-//Contact: frye7@llnl.gov
-//Organization: CASC at LLNL
+// Modified by Zach Frye at LLNL
+// Contact: frye7@llnl.gov
+// Organization: CASC at LLNL
 
 #include <stdio.h>
 #include <inttypes.h>
@@ -33,8 +33,7 @@
 #include <iostream>
 #include <fstream>
 
-
-//variorum trial run
+// variorum trial run
 extern "C" {
 #include <variorum.h>
 #include <jansson.h>
@@ -48,7 +47,6 @@ extern "C" {
 #include <mpi.h>
 #endif
 
-
 bool filterKernels;
 uint64_t nextKernelID;
 std::vector<std::regex> kernelNames;
@@ -59,361 +57,366 @@ typedef void (*finalizeFunction)();
 typedef void (*beginFunction)(const char*, const uint32_t, uint64_t*);
 typedef void (*endFunction)(uint64_t);
 
-static initFunction initProfileLibrary = NULL;
+static initFunction initProfileLibrary         = NULL;
 static finalizeFunction finalizeProfileLibrary = NULL;
-static beginFunction beginForCallee = NULL;
-static beginFunction beginScanCallee = NULL;
-static beginFunction beginReduceCallee = NULL;
-static endFunction endForCallee = NULL;
-static endFunction endScanCallee = NULL;
-static endFunction endReduceCallee = NULL;
+static beginFunction beginForCallee            = NULL;
+static beginFunction beginScanCallee           = NULL;
+static beginFunction beginReduceCallee         = NULL;
+static endFunction endForCallee                = NULL;
+static endFunction endScanCallee               = NULL;
+static endFunction endReduceCallee             = NULL;
 
-//the output path for ranekd output files
+// the output path for ranekd output files
 std::string printpath = "./";
 
-
-
-//variables for simple timer
+// variables for simple timer
 time_t start_time;
 
-int type_of_profiling = 0; // 0 is for both print power & json, 1 is for print power, 2 is for json
-bool usingMPI = false;
+int type_of_profiling =
+    0;  // 0 is for both print power & json, 1 is for print power, 2 is for json
+bool usingMPI     = false;
 bool verbosePrint = false;
-bool mpiOutPut = false;
+bool mpiOutPut    = false;
 
-
-//Function: variorum_print_power_call
-//Description: Prints out power data in two ways: Verbose and non verbose.
-//             verbose will print out each component of the systems power draw in the sierra architecture.
-//             non-verbose will print the node power.
-//Pre: None
-//Post: Will print an error message if variorum print power fails. No return value. 
+// Function: variorum_print_power_call
+// Description: Prints out power data in two ways: Verbose and non verbose.
+//              verbose will print out each component of the systems power draw
+//              in the sierra architecture. non-verbose will print the node
+//              power.
+// Pre: None
+// Post: Will print an error message if variorum print power fails. No return
+// value.
 std::string variorum_print_power_call() {
-    std::string outputString;
-    json_t *power_obj  = json_object(); 
-    double power_node, power_sock0, power_mem0, power_gpu0; 
-    double power_sock1, power_mem1, power_gpu1;
-    int ret;
-	ret = variorum_get_node_power_json(power_obj);
-    if (ret != 0) {
-        return "Print power failed!\n";
-    }
-    //total node measurment
-    power_node =  json_real_value(json_object_get(power_obj, "power_node"));
-    const char * hostnameChar = json_string_value(json_object_get(power_obj, "hostname"));
-    std::string hostname(hostnameChar);
-    //print informatin to screen
-    if(verbosePrint) {
-        //socket 1 measurements
-        power_sock0 =  json_real_value(json_object_get(power_obj, "power_cpu_socket_0"));
-        power_mem0 =  json_real_value(json_object_get(power_obj, "power_mem_socket_0"));
-        power_gpu0 =  json_real_value(json_object_get(power_obj, "power_gpu_socket_0"));
-        //socket 2 measurements
-        power_sock1 =  json_real_value(json_object_get(power_obj, "power_cpu_socket_1"));
-        power_mem1 =  json_real_value(json_object_get(power_obj, "power_mem_socket_1"));
-        power_gpu1 =  json_real_value(json_object_get(power_obj, "power_gpu_socket_1"));
-        
-        outputString += "HostName "+hostname+"\n";
-        outputString += "Total Node Power: "+ std::to_string(power_node);
-        outputString += "\n Socket 1 Power";
-        outputString += "\n CPU Socket 1: "+ std::to_string(power_sock0);
-        outputString += "\n Mem Socket 1: "+ std::to_string(power_mem0);
-        outputString += "\n GPU Socket 1: "+ std::to_string(power_gpu0);
-        outputString += "\n Socket 2 Power";
-        outputString += "\n CPU Socket 2: "+ std::to_string(power_sock1);
-        outputString += "\n Mem Socket 2: "+ std::to_string(power_mem1);
-        outputString += "\n GPU Socket 2: "+ std::to_string(power_gpu1)+"\n"; 
-    } else {
-        outputString += hostname + ": " + std::to_string(power_node) + "\n";
-    }
+  std::string outputString;
+  json_t* power_obj = json_object();
+  double power_node, power_sock0, power_mem0, power_gpu0;
+  double power_sock1, power_mem1, power_gpu1;
+  int ret;
+  ret = variorum_get_node_power_json(power_obj);
+  if (ret != 0) {
+    return "Print power failed!\n";
+  }
+  // total node measurment
+  power_node = json_real_value(json_object_get(power_obj, "power_node"));
+  const char* hostnameChar =
+      json_string_value(json_object_get(power_obj, "hostname"));
+  std::string hostname(hostnameChar);
+  // print informatin to screen
+  if (verbosePrint) {
+    // socket 1 measurements
+    power_sock0 =
+        json_real_value(json_object_get(power_obj, "power_cpu_socket_0"));
+    power_mem0 =
+        json_real_value(json_object_get(power_obj, "power_mem_socket_0"));
+    power_gpu0 =
+        json_real_value(json_object_get(power_obj, "power_gpu_socket_0"));
+    // socket 2 measurements
+    power_sock1 =
+        json_real_value(json_object_get(power_obj, "power_cpu_socket_1"));
+    power_mem1 =
+        json_real_value(json_object_get(power_obj, "power_mem_socket_1"));
+    power_gpu1 =
+        json_real_value(json_object_get(power_obj, "power_gpu_socket_1"));
 
-    return outputString;
+    outputString += "HostName " + hostname + "\n";
+    outputString += "Total Node Power: " + std::to_string(power_node);
+    outputString += "\n Socket 1 Power";
+    outputString += "\n CPU Socket 1: " + std::to_string(power_sock0);
+    outputString += "\n Mem Socket 1: " + std::to_string(power_mem0);
+    outputString += "\n GPU Socket 1: " + std::to_string(power_gpu0);
+    outputString += "\n Socket 2 Power";
+    outputString += "\n CPU Socket 2: " + std::to_string(power_sock1);
+    outputString += "\n Mem Socket 2: " + std::to_string(power_mem1);
+    outputString += "\n GPU Socket 2: " + std::to_string(power_gpu1) + "\n";
+  } else {
+    outputString += hostname + ": " + std::to_string(power_node) + "\n";
+  }
+
+  return outputString;
 }
 
-//Function: variorum_json_call()
-//Description: function that will call variorum print json and handle the execution errors
-//Pre: None
-//Post: Will print an error message if variorum print json fails. No return value. 
-char * variorum_json_call() {
-    int ret;
-	json_t *my_power_obj = NULL;
-	my_power_obj =
-        json_object();
-    ret = variorum_get_node_power_json(my_power_obj);
-    if (ret != 0)
-    {
-        printf("First run: JSON get node power failed!\n");
-    }
-    char *s = json_dumps(my_power_obj, 0);
-    return s;
+// Function: variorum_json_call()
+// Description: function that will call variorum print json and handle the
+// execution errors Pre: None Post: Will print an error message if variorum
+// print json fails. No return value.
+char* variorum_json_call() {
+  int ret;
+  json_t* my_power_obj = NULL;
+  my_power_obj         = json_object();
+  ret                  = variorum_get_node_power_json(my_power_obj);
+  if (ret != 0) {
+    printf("First run: JSON get node power failed!\n");
+  }
+  char* s = json_dumps(my_power_obj, 0);
+  return s;
 }
 
-
-//Function: variorum_call_mpi
-//Description: This function will call the variourm helper functions and either write them to
-//             output files or to std::cout depending on what options are selected
-//Pre: None
-//Post: An output message if variourum returned an error or if it functioned correctly
+// Function: variorum_call_mpi
+// Description: This function will call the variourm helper functions and either
+// write them to
+//              output files or to std::cout depending on what options are
+//              selected
+// Pre: None
+// Post: An output message if variourum returned an error or if it functioned
+// correctly
 void variorum_call_mpi() {
-     if(usingMPI == true) {
-        int rank;
-        std::string output;
-        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-        std::ofstream file; 
+  if (usingMPI == true) {
+    int rank;
+    std::string output;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    std::ofstream file;
+    std::ofstream pfile;
+    if (type_of_profiling ==
+        0) {  // if both print power and json options selected
+      if (mpiOutPut) {
+        std::string filenamejson = printpath + "variorum-output-mpi-rank-" +
+                                   std::to_string(rank) + "-json.txt";
+        std::string filenameprintp = printpath + "variorum-output-mpi-rank-" +
+                                     std::to_string(rank) + ".txt";
+
+        file.open(filenamejson, std::ios_base::app);
         std::ofstream pfile;
-        if (type_of_profiling == 0) { //if both print power and json options selected
-            if (mpiOutPut) {
-                std::string filenamejson = printpath+"variorum-output-mpi-rank-"+std::to_string(rank)+"-json.txt";
-                std::string filenameprintp = printpath+"variorum-output-mpi-rank-"+std::to_string(rank)+".txt";
-                
-                file.open(filenamejson,std::ios_base::app);
-                std::ofstream pfile;
-                pfile.open(filenameprintp,std::ios_base::app);
-                char *s = variorum_json_call();
-                file << s;
-                pfile << variorum_print_power_call();
-            }
-            else {
-                std::cout << "MPI Rank " << rank << "\n";
-                output = variorum_print_power_call();
-                char *s = variorum_json_call();
-                puts(s);
-                std::cout << s << std::endl;
-            }
+        pfile.open(filenameprintp, std::ios_base::app);
+        char* s = variorum_json_call();
+        file << s;
+        pfile << variorum_print_power_call();
+      } else {
+        std::cout << "MPI Rank " << rank << "\n";
+        output  = variorum_print_power_call();
+        char* s = variorum_json_call();
+        puts(s);
+        std::cout << s << std::endl;
+      }
 
-
-        }
-        else if (type_of_profiling == 1) { //if only print power is selected
-            if (mpiOutPut) {
-                std::string filenameprintp = printpath+"variorum-output-mpi-rank-"+std::to_string(rank)+".txt";
-                std::ofstream pfile;
-                pfile.open(filenameprintp,std::ios_base::app);
-                pfile << variorum_print_power_call();
-            }
-            else {
-                std::cout << "MPI Rank " << rank << "\n";
-                output = variorum_print_power_call();
-                std::cout << output << std::endl;
-            }
-        }
-        else if (type_of_profiling == 2) { //if only json is selecte 
-            if (mpiOutPut) {
-                std::string filenamejson = printpath+"variorum-output-mpi-rank-"+std::to_string(rank)+"-json.txt";
-                std::ofstream file; 
-                file.open(filenamejson,std::ios_base::app);
-                char *s = variorum_json_call();
-                file << s;
-            }
-            else {
-                std::cout << "MPI Rank " << rank << "\n";
-                char *s = variorum_json_call();
-                puts(s);
-                std::cout << s << std::endl;
-            }
-        }
-        file.close();
+    } else if (type_of_profiling == 1) {  // if only print power is selected
+      if (mpiOutPut) {
+        std::string filenameprintp = printpath + "variorum-output-mpi-rank-" +
+                                     std::to_string(rank) + ".txt";
+        std::ofstream pfile;
+        pfile.open(filenameprintp, std::ios_base::app);
+        pfile << variorum_print_power_call();
+      } else {
+        std::cout << "MPI Rank " << rank << "\n";
+        output = variorum_print_power_call();
+        std::cout << output << std::endl;
+      }
+    } else if (type_of_profiling == 2) {  // if only json is selecte
+      if (mpiOutPut) {
+        std::string filenamejson = printpath + "variorum-output-mpi-rank-" +
+                                   std::to_string(rank) + "-json.txt";
+        std::ofstream file;
+        file.open(filenamejson, std::ios_base::app);
+        char* s = variorum_json_call();
+        file << s;
+      } else {
+        std::cout << "MPI Rank " << rank << "\n";
+        char* s = variorum_json_call();
+        puts(s);
+        std::cout << s << std::endl;
+      }
     }
-    
+    file.close();
+  }
 }
 
-//Function: variorum_call
-//Description: The function determines what profiling options are selected and prints the profoiling data out to std out
-//Pre: None
-//Post: An output message if variourum returned an error or if it functioned correctly 
+// Function: variorum_call
+// Description: The function determines what profiling options are selected and
+// prints the profoiling data out to std out Pre: None Post: An output message
+// if variourum returned an error or if it functioned correctly
 
 void variorum_call() {
-    std::string output;
-     if (type_of_profiling == 0) { 
-        output = variorum_print_power_call();
-        char *s = variorum_json_call();
-        std::cout << s << "\n";
-        std::cout << output << std::endl;
-    }
-    else if (type_of_profiling == 1) {
-        output = variorum_print_power_call();
-        std::cout << output << std::endl;
-    }
-    else if (type_of_profiling == 2) {
-        char *s = variorum_json_call();
-        std::cout << s << std::endl;
-    }
+  std::string output;
+  if (type_of_profiling == 0) {
+    output  = variorum_print_power_call();
+    char* s = variorum_json_call();
+    std::cout << s << "\n";
+    std::cout << output << std::endl;
+  } else if (type_of_profiling == 1) {
+    output = variorum_print_power_call();
+    std::cout << output << std::endl;
+  } else if (type_of_profiling == 2) {
+    char* s = variorum_json_call();
+    std::cout << s << std::endl;
+  }
 }
 
-
 extern "C" void kokkosp_init_library(const int loadSeq,
-	const uint64_t interfaceVer, const uint32_t devInfoCount, void* deviceInfo) {
-    
-    char * outputPathChar;
-    try {
-        outputPathChar = getenv("VARIORUM_OUTPUT_PATH");
-        if (outputPathChar==NULL) {
-            throw 10;
-        }
-        std::string outputPathStr(outputPathChar);
-        printpath = outputPathStr;
-        std::cout << "Output Path set to" << outputPathChar << "\n";
-    } catch (int e) {
-        if( e == 10) {
-            printpath = "./";
-            std::cout << "No output path provided, the application will output to the default path \n";
-        }
+                                     const uint64_t interfaceVer,
+                                     const uint32_t devInfoCount,
+                                     void* deviceInfo) {
+  char* outputPathChar;
+  try {
+    outputPathChar = getenv("VARIORUM_OUTPUT_PATH");
+    if (outputPathChar == NULL) {
+      throw 10;
     }
+    std::string outputPathStr(outputPathChar);
+    printpath = outputPathStr;
+    std::cout << "Output Path set to" << outputPathChar << "\n";
+  } catch (int e) {
+    if (e == 10) {
+      printpath = "./";
+      std::cout << "No output path provided, the application will output to "
+                   "the default path \n";
+    }
+  }
 
-    //Profiling options are read in from their enviornment variables and the options are set
-    char* profiling_type;
-    try {
-        profiling_type = getenv("KOKKOS_VARIORUM_FUNC_TYPE");
-        if (profiling_type==NULL) {
-            throw 10;
-        }
-        if(strcmp(profiling_type, "ppower") == 0) {
-        type_of_profiling = 1;
-        std::cout << "Variorum print power will be called\n";
-        if(verbosePrint == true) {
-            std::cout << "Power Format: \n Hostname: total node power, cpuSocket1, memScoket1, gpuSocket1, cpuSocket2, memScoket2, gpuSocket2 \n";
-        } 
-        }
-        else if(strcmp(profiling_type, "json") == 0) {
-            type_of_profiling = 2;
-        }
-        else if(strcmp(profiling_type, "both") == 0) {
-            type_of_profiling = 0;
-        }
-    } catch (int e) {
-        if( e == 10) {
-            type_of_profiling = 0;
-            std::cout << "No profiling options provided, profiling tool will call variorum print power and json \n";
-        }
+  // Profiling options are read in from their enviornment variables and the
+  // options are set
+  char* profiling_type;
+  try {
+    profiling_type = getenv("KOKKOS_VARIORUM_FUNC_TYPE");
+    if (profiling_type == NULL) {
+      throw 10;
     }
-    try {
-        char* verbosePrintStr = getenv("VERBOSE");
-        if (verbosePrintStr == NULL) {
-            throw 10;
+    if (strcmp(profiling_type, "ppower") == 0) {
+      type_of_profiling = 1;
+      std::cout << "Variorum print power will be called\n";
+      if (verbosePrint == true) {
+        std::cout
+            << "Power Format: \n Hostname: total node power, cpuSocket1, "
+               "memScoket1, gpuSocket1, cpuSocket2, memScoket2, gpuSocket2 \n";
+      }
+    } else if (strcmp(profiling_type, "json") == 0) {
+      type_of_profiling = 2;
+    } else if (strcmp(profiling_type, "both") == 0) {
+      type_of_profiling = 0;
+    }
+  } catch (int e) {
+    if (e == 10) {
+      type_of_profiling = 0;
+      std::cout << "No profiling options provided, profiling tool will call "
+                   "variorum print power and json \n";
+    }
+  }
+  try {
+    char* verbosePrintStr = getenv("VERBOSE");
+    if (verbosePrintStr == NULL) {
+      throw 10;
+    }
+    if (strcmp(verbosePrintStr, "false") == 0 ||
+        strcmp(verbosePrintStr, "") == 0) {
+      throw 20;
+    } else if (strcmp(verbosePrintStr, "true") == 0) {
+      std::cout << "Verbose power option set"
+                << "\n";
+      verbosePrint = true;
+    }
+  } catch (int e) {
+    verbosePrint = false;
+    std::cout << "No verbose options provided, power information outut will "
+                 "not be verbose \n Format - Hosntame : Node power value\n";
+  }
+  try {
+    char* usingMPIstr = getenv("VARIORUM_USING_MPI");
+    if (usingMPIstr == NULL) {
+      throw 10;
+    }
+    if (strcmp(usingMPIstr, "false") == 0 || strcmp(usingMPIstr, "") == 0) {
+      throw 20;
+    }
+    if (strcmp(usingMPIstr, "true") == 0) {
+      usingMPI = true;
+      try {
+        char* perRankOutput = getenv("RANKED_OUTPUT");
+        if (strcmp(perRankOutput, "false") == 0 ||
+            strcmp(perRankOutput, "") == 0) {
+          mpiOutPut = false;
+        } else if (strcmp(perRankOutput, "true") == 0) {
+          mpiOutPut = true;
+        } else {
+          mpiOutPut = false;
         }
-        if (strcmp(verbosePrintStr, "false") == 0|| strcmp(verbosePrintStr, "") == 0 ) {
-            throw 20;
-        }
-        else if (strcmp(verbosePrintStr, "true") == 0) {
-            std::cout << "Verbose power option set" << "\n";
-    		verbosePrint = true;
-	    }
-    } catch (int e) {
-        verbosePrint = false;
-        std::cout << "No verbose options provided, power information outut will not be verbose \n Format - Hosntame : Node power value\n";
 
+      } catch (int f) {
+        std::cout << "Ranked output will no be used, error setting paramters"
+                  << std::endl;
+        mpiOutPut = false;
+      }
     }
-    try {
-        char* usingMPIstr = getenv("VARIORUM_USING_MPI");
-        if (usingMPIstr == NULL) {
-            throw 10;
-        }
-        if (strcmp(usingMPIstr, "false") == 0|| strcmp(usingMPIstr, "") == 0 ) {
-            throw 20;
-        }
-        if (strcmp(usingMPIstr, "true") == 0) {
-    		usingMPI = true;
-            try{ 
-                char* perRankOutput = getenv("RANKED_OUTPUT");
-                if (strcmp(perRankOutput, "false") == 0|| strcmp(perRankOutput, "") == 0 ) {
-                    mpiOutPut = false;
-                }
-                else if (strcmp(perRankOutput, "true") == 0 ) {
-                    mpiOutPut = true;
-                }
-                else {
-                    mpiOutPut = false;
-                }
+  } catch (int e) {
+    std::cout << "No MPI Option provided, not using per rank output"
+              << std::endl;
+    usingMPI = false;
+  }
+  // Simple timer code to keep track of the general amount of time the
+  // application ran for.
+  time(&start_time);
+  std::cout << "Start Time: " << start_time << "\n";
 
-            } 
-            catch(int f) {
-                std::cout << "Ranked output will no be used, error setting paramters" << std::endl;
-                mpiOutPut = false;
-            }
-	    }
-    } catch (int e) {
-        std::cout << "No MPI Option provided, not using per rank output" << std::endl;    
-        usingMPI = false;
-    }
-    //Simple timer code to keep track of the general amount of time the application ran for.
-    time(&start_time);
-    std::cout << "Start Time: " << start_time << "\n";
-    
-    //variorum_call();
-    
+  // variorum_call();
 }
 
 extern "C" void kokkosp_finalize_library() {
+  if (usingMPI) {
+    variorum_call_mpi();
+  } else {
+    variorum_call();
+  }
+  time_t total_time;
+  time_t end_time;
+  time(&end_time);
+  std::cout << "End Time: " << end_time << "\nStart Time: " << start_time
+            << "\n";
+  total_time = end_time - start_time;
 
-    if(usingMPI) {
-        variorum_call_mpi();
-    }
-    else {
-        variorum_call();
-    }
-    time_t total_time;
-    time_t end_time;
-    time(&end_time);
-    std::cout << "End Time: " << end_time << "\nStart Time: " << start_time << "\n";
-    total_time = end_time - start_time;
-
-    std::cout << "The kokkos library was alive for " << total_time << " seconds." << std::endl;
+  std::cout << "The kokkos library was alive for " << total_time << " seconds."
+            << std::endl;
 }
 
-extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devID, uint64_t* kID) {
-    std::cout << "Device ID: " << devID << "\n";
-    if(usingMPI) {
-        variorum_call_mpi();
-    }
-    else {
-        variorum_call();
-    }
+extern "C" void kokkosp_begin_parallel_for(const char* name,
+                                           const uint32_t devID,
+                                           uint64_t* kID) {
+  std::cout << "Device ID: " << devID << "\n";
+  if (usingMPI) {
+    variorum_call_mpi();
+  } else {
+    variorum_call();
+  }
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
-    if(usingMPI) {
-        variorum_call_mpi();
-    }
-    else {
-        variorum_call();
-    }
+  if (usingMPI) {
+    variorum_call_mpi();
+  } else {
+    variorum_call();
+  }
 }
 
-extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID, uint64_t* kID) {
-	std::cout << "Device ID: " << devID << "\n";
-    if(usingMPI) {
-        variorum_call_mpi();
-    }
-    else {
-        variorum_call();
-    }
+extern "C" void kokkosp_begin_parallel_scan(const char* name,
+                                            const uint32_t devID,
+                                            uint64_t* kID) {
+  std::cout << "Device ID: " << devID << "\n";
+  if (usingMPI) {
+    variorum_call_mpi();
+  } else {
+    variorum_call();
+  }
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
-    if(usingMPI) {
-        variorum_call_mpi();
-    }
-    else {
-        variorum_call();
-    }	
+  if (usingMPI) {
+    variorum_call_mpi();
+  } else {
+    variorum_call();
+  }
 }
 
-extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID, uint64_t* kID) {
-    std::cout << "Device ID: " << devID << "\n";
-    if(usingMPI) {
-        variorum_call_mpi();
-    }
-    else {
-        variorum_call();
-    }
+extern "C" void kokkosp_begin_parallel_reduce(const char* name,
+                                              const uint32_t devID,
+                                              uint64_t* kID) {
+  std::cout << "Device ID: " << devID << "\n";
+  if (usingMPI) {
+    variorum_call_mpi();
+  } else {
+    variorum_call();
+  }
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
-    if(usingMPI) {
-        variorum_call_mpi();
-    }
-    else {
-        variorum_call();
-    }
+  if (usingMPI) {
+    variorum_call_mpi();
+  } else {
+    variorum_call();
+  }
 }
-
-

--- a/profiling/vtune-connector/kp_vtune_connector.cpp
+++ b/profiling/vtune-connector/kp_vtune_connector.cpp
@@ -29,98 +29,103 @@ static std::unordered_map<std::string, KernelVTuneConnectorInfo*> domain_map;
 static uint64_t nextKernelID;
 
 extern "C" void kokkosp_init_library(const int loadSeq,
-	const uint64_t interfaceVer,
-	const uint32_t devInfoCount,
-	void* deviceInfo) {
+                                     const uint64_t interfaceVer,
+                                     const uint32_t devInfoCount,
+                                     void* deviceInfo) {
+  printf("-----------------------------------------------------------\n");
+  printf("KokkosP: VTune Analyzer Connector (sequence is %d, version: %llu)\n",
+         loadSeq, interfaceVer);
+  printf("-----------------------------------------------------------\n");
 
-	printf("-----------------------------------------------------------\n");
-	printf("KokkosP: VTune Analyzer Connector (sequence is %d, version: %llu)\n", loadSeq, interfaceVer);
-	printf("-----------------------------------------------------------\n");
-
-	nextKernelID = 0;
-	const char* kpStartEventName = "Kokkos Initialization Complete";
-	__itt_event startEv = __itt_event_create( kpStartEventName, strlen(kpStartEventName) );
-	__itt_event_start(startEv);
+  nextKernelID                 = 0;
+  const char* kpStartEventName = "Kokkos Initialization Complete";
+  __itt_event startEv =
+      __itt_event_create(kpStartEventName, strlen(kpStartEventName));
+  __itt_event_start(startEv);
 }
 
 extern "C" void kokkosp_finalize_library() {
-	printf("-----------------------------------------------------------\n");
-	printf("KokkosP: Finalization of VTune Connector. Complete.\n");
-	printf("-----------------------------------------------------------\n");
+  printf("-----------------------------------------------------------\n");
+  printf("KokkosP: Finalization of VTune Connector. Complete.\n");
+  printf("-----------------------------------------------------------\n");
 
-	const char* kpFinalizeEventName = "Kokkos Finalize Complete";
-	__itt_event finalEv = __itt_event_create( kpFinalizeEventName, strlen(kpFinalizeEventName) );
-	__itt_event_start(finalEv);
+  const char* kpFinalizeEventName = "Kokkos Finalize Complete";
+  __itt_event finalEv =
+      __itt_event_create(kpFinalizeEventName, strlen(kpFinalizeEventName));
+  __itt_event_start(finalEv);
 }
 
-extern "C" void kokkosp_begin_parallel_for(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = nextKernelID++;
+extern "C" void kokkosp_begin_parallel_for(const char* name,
+                                           const uint32_t devID,
+                                           uint64_t* kID) {
+  *kID = nextKernelID++;
 
-	std::string nameStr(name);
-	auto kDomain = domain_map.find(nameStr);
-	currentKernel = NULL;
+  std::string nameStr(name);
+  auto kDomain  = domain_map.find(nameStr);
+  currentKernel = NULL;
 
-	if(kDomain == domain_map.end()) {
-		currentKernel = new KernelVTuneConnectorInfo(name, PARALLEL_FOR);
-		domain_map.insert(std::pair<std::string, KernelVTuneConnectorInfo*>(nameStr,
-			currentKernel));
-	} else {
-		currentKernel = kDomain->second;
-	}
+  if (kDomain == domain_map.end()) {
+    currentKernel = new KernelVTuneConnectorInfo(name, PARALLEL_FOR);
+    domain_map.insert(std::pair<std::string, KernelVTuneConnectorInfo*>(
+        nameStr, currentKernel));
+  } else {
+    currentKernel = kDomain->second;
+  }
 
-	__itt_frame_begin_v3(currentKernel->getDomain(), NULL);
+  __itt_frame_begin_v3(currentKernel->getDomain(), NULL);
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
-	__itt_frame_end_v3(currentKernel->getDomain(), NULL);
-	currentKernel = NULL;
+  __itt_frame_end_v3(currentKernel->getDomain(), NULL);
+  currentKernel = NULL;
 }
 
-extern "C" void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = nextKernelID++;
+extern "C" void kokkosp_begin_parallel_scan(const char* name,
+                                            const uint32_t devID,
+                                            uint64_t* kID) {
+  *kID = nextKernelID++;
 
-	std::string nameStr(name);
-	auto kDomain = domain_map.find(nameStr);
-	currentKernel = NULL;
+  std::string nameStr(name);
+  auto kDomain  = domain_map.find(nameStr);
+  currentKernel = NULL;
 
-	if(kDomain == domain_map.end()) {
-		currentKernel = new KernelVTuneConnectorInfo(name, PARALLEL_SCAN);
-		domain_map.insert(std::pair<std::string, KernelVTuneConnectorInfo*>(nameStr,
-			currentKernel));
-	} else {
-		currentKernel = kDomain->second;
-	}
+  if (kDomain == domain_map.end()) {
+    currentKernel = new KernelVTuneConnectorInfo(name, PARALLEL_SCAN);
+    domain_map.insert(std::pair<std::string, KernelVTuneConnectorInfo*>(
+        nameStr, currentKernel));
+  } else {
+    currentKernel = kDomain->second;
+  }
 
-	__itt_frame_begin_v3(currentKernel->getDomain(), NULL);
-
+  __itt_frame_begin_v3(currentKernel->getDomain(), NULL);
 }
 
 extern "C" void kokkosp_end_parallel_scan(const uint64_t kID) {
-	__itt_frame_end_v3(currentKernel->getDomain(), NULL);
-	currentKernel = NULL;
+  __itt_frame_end_v3(currentKernel->getDomain(), NULL);
+  currentKernel = NULL;
 }
 
-extern "C" void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID, uint64_t* kID) {
-	*kID = nextKernelID++;
+extern "C" void kokkosp_begin_parallel_reduce(const char* name,
+                                              const uint32_t devID,
+                                              uint64_t* kID) {
+  *kID = nextKernelID++;
 
-	std::string nameStr(name);
-	auto kDomain = domain_map.find(nameStr);
-	currentKernel = NULL;
+  std::string nameStr(name);
+  auto kDomain  = domain_map.find(nameStr);
+  currentKernel = NULL;
 
-	if(kDomain == domain_map.end()) {
-		currentKernel = new KernelVTuneConnectorInfo(name, PARALLEL_REDUCE);
-		domain_map.insert(std::pair<std::string, KernelVTuneConnectorInfo*>(nameStr,
-			currentKernel));
-	} else {
-		currentKernel = kDomain->second;
-	}
+  if (kDomain == domain_map.end()) {
+    currentKernel = new KernelVTuneConnectorInfo(name, PARALLEL_REDUCE);
+    domain_map.insert(std::pair<std::string, KernelVTuneConnectorInfo*>(
+        nameStr, currentKernel));
+  } else {
+    currentKernel = kDomain->second;
+  }
 
-	__itt_frame_begin_v3(currentKernel->getDomain(), NULL);
-
+  __itt_frame_begin_v3(currentKernel->getDomain(), NULL);
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
-	__itt_frame_end_v3(currentKernel->getDomain(), NULL);
-	currentKernel = NULL;
+  __itt_frame_end_v3(currentKernel->getDomain(), NULL);
+  currentKernel = NULL;
 }
-

--- a/profiling/vtune-connector/kp_vtune_connector.cpp
+++ b/profiling/vtune-connector/kp_vtune_connector.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #include <stdio.h>

--- a/profiling/vtune-connector/kp_vtune_connector_domain.h
+++ b/profiling/vtune-connector/kp_vtune_connector_domain.h
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #ifndef _H_KOKKOSP_KERNEL_VTUNE_CONNECTOR_INFO

--- a/profiling/vtune-connector/kp_vtune_connector_domain.h
+++ b/profiling/vtune-connector/kp_vtune_connector_domain.h
@@ -24,48 +24,42 @@
 #include "ittnotify.h"
 
 enum KernelExecutionType {
-	PARALLEL_FOR = 0,
-	PARALLEL_REDUCE = 1,
-	PARALLEL_SCAN = 2
+  PARALLEL_FOR    = 0,
+  PARALLEL_REDUCE = 1,
+  PARALLEL_SCAN   = 2
 };
 
 class KernelVTuneConnectorInfo {
-	public:
-		KernelVTuneConnectorInfo(std::string kName, KernelExecutionType kernelType) {
+ public:
+  KernelVTuneConnectorInfo(std::string kName, KernelExecutionType kernelType) {
+    char* domainName = (char*)malloc(sizeof(char*) * (32 + kName.size()));
 
-			char* domainName = (char*) malloc( sizeof(char*) * (32 + kName.size()) );
+    if (kernelType == PARALLEL_FOR) {
+      sprintf(domainName, "ParallelFor.%s", kName.c_str());
+    } else if (kernelType == PARALLEL_REDUCE) {
+      sprintf(domainName, "ParallelReduce.%s", kName.c_str());
+    } else if (kernelType == PARALLEL_SCAN) {
+      sprintf(domainName, "ParallelScan.%s", kName.c_str());
+    } else {
+      sprintf(domainName, "Kernel.%s", kName.c_str());
+    }
 
-			if(kernelType == PARALLEL_FOR) {
-				sprintf(domainName, "ParallelFor.%s", kName.c_str());
-			} else if(kernelType == PARALLEL_REDUCE) {
-				sprintf(domainName, "ParallelReduce.%s", kName.c_str());
-			} else if(kernelType == PARALLEL_SCAN) {
-				sprintf(domainName, "ParallelScan.%s", kName.c_str());
-			} else {
-				sprintf(domainName, "Kernel.%s", kName.c_str());
-			}
+    domain           = __itt_domain_create(domainName);
+    domainNameHandle = __itt_string_handle_create(domainName);
 
-			domain = __itt_domain_create(domainName);
-		 	domainNameHandle = __itt_string_handle_create(domainName);
+    // Enable the domain for profile capture
+    domain->flags = 1;
+  }
 
-			// Enable the domain for profile capture
-			domain->flags = 1;
-		}
+  __itt_domain* getDomain() { return domain; }
 
-		__itt_domain* getDomain() {
-			return domain;
-		}
+  __itt_string_handle* getDomainNameHandle() { return domainNameHandle; }
 
-		__itt_string_handle* getDomainNameHandle() {
-			return domainNameHandle;
-		}
+  ~KernelVTuneConnectorInfo() {}
 
-		~KernelVTuneConnectorInfo() {
-		}
-
-	private:
-		__itt_domain* domain;
-		__itt_string_handle* domainNameHandle;
+ private:
+  __itt_domain* domain;
+  __itt_string_handle* domainNameHandle;
 };
 
 #endif

--- a/profiling/vtune-focused-connector/kp_vtune_focused_connector.cpp
+++ b/profiling/vtune-focused-connector/kp_vtune_focused_connector.cpp
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #include <stdio.h>

--- a/profiling/vtune-focused-connector/kp_vtune_focused_connector_domain.h
+++ b/profiling/vtune-focused-connector/kp_vtune_focused_connector_domain.h
@@ -1,43 +1,17 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 3.0
-//       Copyright (2020) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,
 // the U.S. Government retains certain rights in this software.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 1. Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the Corporation nor the names of the
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// Questions? Contact David Poliakoff (dzpolia@sandia.gov)
-//
-// ************************************************************************
 //@HEADER
 
 #ifndef _H_KOKKOSP_KERNEL_VTUNE_CONNECTOR_INFO

--- a/profiling/vtune-focused-connector/kp_vtune_focused_connector_domain.h
+++ b/profiling/vtune-focused-connector/kp_vtune_focused_connector_domain.h
@@ -24,48 +24,43 @@
 #include "ittnotify.h"
 
 enum KernelExecutionType {
-	PARALLEL_FOR = 0,
-	PARALLEL_REDUCE = 1,
-	PARALLEL_SCAN = 2
+  PARALLEL_FOR    = 0,
+  PARALLEL_REDUCE = 1,
+  PARALLEL_SCAN   = 2
 };
 
 class KernelVTuneFocusedConnectorInfo {
-	public:
-		KernelVTuneFocusedConnectorInfo(std::string kName, KernelExecutionType kernelType) {
+ public:
+  KernelVTuneFocusedConnectorInfo(std::string kName,
+                                  KernelExecutionType kernelType) {
+    char* domainName = (char*)malloc(sizeof(char*) * (32 + kName.size()));
 
-			char* domainName = (char*) malloc( sizeof(char*) * (32 + kName.size()) );
+    if (kernelType == PARALLEL_FOR) {
+      sprintf(domainName, "ParallelFor.%s", kName.c_str());
+    } else if (kernelType == PARALLEL_REDUCE) {
+      sprintf(domainName, "ParallelReduce.%s", kName.c_str());
+    } else if (kernelType == PARALLEL_SCAN) {
+      sprintf(domainName, "ParallelScan.%s", kName.c_str());
+    } else {
+      sprintf(domainName, "Kernel.%s", kName.c_str());
+    }
 
-			if(kernelType == PARALLEL_FOR) {
-				sprintf(domainName, "ParallelFor.%s", kName.c_str());
-			} else if(kernelType == PARALLEL_REDUCE) {
-				sprintf(domainName, "ParallelReduce.%s", kName.c_str());
-			} else if(kernelType == PARALLEL_SCAN) {
-				sprintf(domainName, "ParallelScan.%s", kName.c_str());
-			} else {
-				sprintf(domainName, "Kernel.%s", kName.c_str());
-			}
+    domain           = __itt_domain_create(domainName);
+    domainNameHandle = __itt_string_handle_create(domainName);
 
-			domain = __itt_domain_create(domainName);
-		 	domainNameHandle = __itt_string_handle_create(domainName);
+    // Enable the domain for profile capture
+    domain->flags = 1;
+  }
 
-			// Enable the domain for profile capture
-			domain->flags = 1;
-		}
+  __itt_domain* getDomain() { return domain; }
 
-		__itt_domain* getDomain() {
-			return domain;
-		}
+  __itt_string_handle* getDomainNameHandle() { return domainNameHandle; }
 
-		__itt_string_handle* getDomainNameHandle() {
-			return domainNameHandle;
-		}
+  ~KernelVTuneFocusedConnectorInfo() {}
 
-		~KernelVTuneFocusedConnectorInfo() {
-		}
-
-	private:
-		__itt_domain* domain;
-		__itt_string_handle* domainNameHandle;
+ private:
+  __itt_domain* domain;
+  __itt_string_handle* domainNameHandle;
 };
 
 #endif


### PR DESCRIPTION
Fixes build system default flag settings so that when one types  

cmake .. 

Kokkos Tools should just work, at least on most machines of interest to Kokkos.

Currently tested is MacOSX and ongoing testing is on Perlmutter and other DoE ECP supercomputers. 